### PR TITLE
Fix Arch Linux configuration

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class chrony::params {
       $config_keys_owner = 0
       $config_keys_group = 0
       $config_keys_mode  = '0644'
-      $service_name      = 'chrony'
+      $service_name      = 'chronyd'
       $clientlog         = true
       $rtconutc          = true
       $dumpdir           = '/var/log/chrony'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class chrony::params {
       $service_name      = 'chronyd'
       $clientlog         = true
       $rtconutc          = true
-      $dumpdir           = '/var/log/chrony'
+      $dumpdir           = '/var/lib/chrony'
     }
     'Gentoo' : {
       $package_name      = 'net-misc/chrony'

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -304,7 +304,7 @@ describe 'chrony' do
         when 'Archlinux'
           context 'using defaults' do
             it do
-              is_expected.to contain_service('chrony').with(
+              is_expected.to contain_service('chronyd').with(
                 ensure: 'running',
                 enable: true,
               )

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -33,7 +33,7 @@ describe 'chrony' do
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtcsync$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/log/chrony$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/lib/chrony$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*\n\s*$}) }
             it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0644') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }


### PR DESCRIPTION
The service name chrony in Arch Linux is `chronyd`, and the package defines a location under `/var/lib/chrony` for the service to store data instead of `/etc`.

The module is currently broken for Arch Linux out of the box, running the latest version of chrony from the official repos. These changes will allow new instances to work correctly, and shouldn't have much impact on existing installations. 