### PR TITLE
Remove default value of 0 for $port and allow $port to be unset

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -364,7 +364,6 @@ Default value: 3
 Data type: `Any`
 
 This adds the networks, hosts that are allowed to query the daemon.
-Note that `port` needs to be set for this to work.
 
 Default value: []
 
@@ -373,9 +372,8 @@ Default value: []
 Data type: `Stdlib::Port`
 
 Port the service should listen on, to be used in combination with `queryhosts`.
-Module default is `0` to prevent accidental activation of server mode.
 
-Default value: 0
+Default value: `undef`
 
 ##### `service_enable`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -206,7 +206,7 @@ class chrony (
   Optional[String[1]] $mailonchange                                = undef,
   Float $threshold                                                 = 0.5,
   Boolean $lock_all                                                = false,
-  Stdlib::Port $port                                               = 0,
+  Optional[Stdlib::Port] $port                                     = undef,
   Boolean $clientlog                                               = $chrony::params::clientlog,
   Optional[Integer] $clientloglimit                                = undef,
   Boolean $service_enable                                          = true,
@@ -223,10 +223,6 @@ class chrony (
 
   if ! $config_keys_manage and $chrony_password != 'unset'  {
     fail("Setting \$config_keys_manage false and \$chrony_password at same time in ${module_name} is not possible.")
-  }
-
-  if $queryhosts != [] and $port == 0 {
-    fail("Setting \$queryhosts has no effect unless also setting \$port which defaults to 0 in ${module_name}, refusing that.")
   }
 
   contain 'chrony::install'

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -26,7 +26,6 @@ describe 'chrony' do
         case facts[:osfamily]
         when 'Archlinux'
           context 'using defaults' do
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 0$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 127\.0\.0\.1$}) }
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
@@ -40,7 +39,6 @@ describe 'chrony' do
           end
         when 'RedHat'
           context 'using defaults' do
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 0$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
             it { is_expected.not_to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow.*$}) }
@@ -55,7 +53,6 @@ describe 'chrony' do
           end
         when 'Debian'
           context 'using defaults' do
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 0$}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
             it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow.*$}) }
@@ -215,16 +212,6 @@ describe 'chrony' do
         end
 
         it { is_expected.to raise_error(%r{Setting \$config_keys_manage false and \$chrony_password at same time in chrony is not possible}) }
-      end
-
-      context 'queryhosts set but port left at default 0' do
-        let(:params) do
-          {
-            queryhosts: ['192.168/16'],
-          }
-        end
-
-        it { is_expected.to raise_error(%r{Setting \$queryhosts has no effect unless also setting \$port which defaults to 0 in chrony, refusing that}) }
       end
 
       context 'on any other system' do


### PR DESCRIPTION
Also remove the requirement for $port to be set if $qeryhost is used. If there is no
'allow' in chrony.conf the server doesn't allow client access, no need to also set port to
0. And if there is 'allow' in chrony.conf the default port to listen on is the expected
123.

From chrony.conf(5)

   port port
       This option allows the UDP port on which the server understands NTP requests to be
       specified. For normal servers this option should not be required (the default is 123,
       the standard NTP port).