### PR TITLE
Add new `driftfile`, `hwtimestamps`, `rtcsync`, and `dumpdir` parameters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -177,6 +177,14 @@ This sets the file to write chrony keys into.
 
 Default value: $chrony::params::config_keys
 
+##### `driftfile`
+
+Data type: `Stdlib::Unixpath`
+
+The file for chrony to record clock drift in.
+
+Default value: '/var/lib/chrony/drift'
+
 ##### `config_keys_manage`
 
 Data type: `Boolean`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -481,6 +481,14 @@ See [clientloglimit](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#clien
 
 Default value: `undef`
 
+##### `rtconutc`
+
+Data type: Boolean
+
+Keep RTC in UTC instead of local time.
+
+Default value: $chrony::params::rtconutc
+
 ##### `hwtimestamps`
 
 Data type: `Variant[Hash,Array[String]]`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -473,3 +473,11 @@ See [clientloglimit](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#clien
 
 Default value: `undef`
 
+##### `hwtimestamps`
+
+Data type: `Variant[Hash,Array[String]]`
+
+This selects interfaces to enable hardware timestamps on. It can be an array of interfaces
+or a hash of interfaces to their respective options.
+
+Default value: []

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -505,3 +505,11 @@ This selects interfaces to enable hardware timestamps on. It can be an array of 
 or a hash of interfaces to their respective options.
 
 Default value: []
+
+##### `dumpdir`
+
+Data type: Optional[Stdlib::Unixpath]
+
+Directory for chrony to store measurement in on exit.
+
+Default value: $chrony::params::dumpdir

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -481,6 +481,14 @@ See [clientloglimit](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#clien
 
 Default value: `undef`
 
+##### `rtcsync`
+
+Data type: Boolean
+
+Periodically sync system time to RTC
+
+Default value: `true'
+
 ##### `rtconutc`
 
 Data type: Boolean

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,8 @@
 # @param hwtimestamps
 #   This selects interfaces to enable hardware timestamps on. It can be an array of
 #   interfaces or a hash of interfaces to their respective options.
+# @param dumpdir
+#   Directory to store measurement history in on exit.
 class chrony (
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
@@ -229,6 +231,7 @@ class chrony (
   Boolean $rtcsync                                                 = true,
   Boolean $rtconutc                                                = $chrony::params::rtconutc,
   Variant[Hash,Array[String]] $hwtimestamps                        = [],
+  Optional[Stdlib::Unixpath] $dumpdir                              = $chrony::params::dumpdir,
 ) inherits chrony::params {
 
   if ! $config_keys_manage and $chrony_password != 'unset'  {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,8 @@
 #   Specify unix mode of chrony keys files, defaults to 0644 on ArchLinux and 0640 on Redhat.
 # @param keys
 #   An array of key lines.  These are printed as-is into the chrony key file.
+# @param driftfile
+#   A file for chrony to record clock drift in.
 # @param local_stratum
 #   Override the stratum of the server which will be reported to clients
 #   when the local reference is active.
@@ -188,6 +190,7 @@ class chrony (
   Stdlib::Filemode $config_keys_mode                               = $chrony::params::config_keys_mode,
   Boolean $config_keys_manage                                      = true,
   Array[String[1]] $keys                                           = [],
+  Stdlib::Unixpath $driftfile                                      = '/var/lib/chrony/drift',
   Integer[1,15] $local_stratum                                     = 10,
   Optional[String[1]] $log_options                                 = undef,
   String[1] $package_ensure                                        = 'present',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,6 +170,9 @@
 #   Keep RTC in UTC instead of local time.
 #   If not set, chrony's, default will be used. On Arch Linux the default is true instead.
 #   See [rtconutc](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#rtconutc)
+# @param hwtimestamps
+#   This selects interfaces to enable hardware timestamps on. It can be an array of
+#   interfaces or a hash of interfaces to their respective options.
 class chrony (
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
@@ -219,6 +222,7 @@ class chrony (
   Optional[Float] $maxslewrate                                     = undef,
   Optional[Numeric] $stratumweight                                 = undef,
   Boolean $rtconutc                                                = $chrony::params::rtconutc,
+  Variant[Hash,Array[String]] $hwtimestamps                        = [],
 ) inherits chrony::params {
 
   if ! $config_keys_manage and $chrony_password != 'unset'  {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,6 +168,8 @@
 #   When set, specifies the maximum amount of memory in bytes that chronyd is allowed to allocate for logging of client accesses.
 #   If not set, chrony's, default will be used. In modern versions this is 524288 bytes.  Older versions defaulted to have no limit.
 #   See [clientloglimit](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#clientloglimit)
+# @param rtcsync
+#  Sync system clock to RTC periodically
 # @param rtconutc
 #   Keep RTC in UTC instead of local time.
 #   If not set, chrony's, default will be used. On Arch Linux the default is true instead.
@@ -224,6 +226,7 @@ class chrony (
   Optional[String] $leapsectz                                      = undef,
   Optional[Float] $maxslewrate                                     = undef,
   Optional[Numeric] $stratumweight                                 = undef,
+  Boolean $rtcsync                                                 = true,
   Boolean $rtconutc                                                = $chrony::params::rtconutc,
   Variant[Hash,Array[String]] $hwtimestamps                        = [],
 ) inherits chrony::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class chrony::params {
       $service_name      = 'chrony'
       $clientlog         = true
       $rtconutc          = true
+      $dumpdir           = '/var/log/chrony'
     }
     'Gentoo' : {
       $package_name      = 'net-misc/chrony'
@@ -26,6 +27,7 @@ class chrony::params {
       $service_name      = 'chronyd'
       $clientlog         = true
       $rtconutc          = true
+      $dumpdir           = undef
     }
     'Suse', 'RedHat' : {
       $package_name      = 'chrony'
@@ -38,6 +40,7 @@ class chrony::params {
       $service_name      = 'chronyd'
       $clientlog         = false
       $rtconutc          = false
+      $dumpdir           = undef
     }
     'Debian' : {
       $package_name      = 'chrony'
@@ -50,6 +53,7 @@ class chrony::params {
       $service_name      = 'chrony'
       $clientlog         = false
       $rtconutc          = false
+      $dumpdir           = undef
     }
 
     default     : {

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -33,6 +33,7 @@ describe 'chrony' do
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtcsync$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/log/chrony$}) }
             it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0644') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_group('0') }
@@ -49,6 +50,7 @@ describe 'chrony' do
             end
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtcsync$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*dumpdir}) }
             it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0640') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_group('chrony') }
@@ -65,6 +67,7 @@ describe 'chrony' do
             end
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*rtcsync$}) }
+            it { is_expected.to contain_file('/etc/chrony/chrony.conf').without_content(%r{^\s*dumpdir}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0640') }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('0') }
@@ -95,6 +98,7 @@ describe 'chrony' do
             hwtimestamps: ['eth0'],
             driftfile: '/var/tmp/chrony.drift',
             rtcsync: false,
+            dumpdir: '/var/tmp',
           }
         end
 
@@ -111,6 +115,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*rtcsync$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/tmp$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -135,6 +140,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*rtcsync$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/tmp$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -158,6 +164,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').without_content(%r{^\s*rtcsync$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*dumpdir /var/tmp$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('mrt') }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -86,6 +86,7 @@ describe 'chrony' do
             maxslewrate: 1000.0,
             smoothtime: '400 0.001 leaponly',
             rtconutc: true,
+            hwtimestamps: ['eth0'],
           }
         end
 
@@ -99,6 +100,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -120,6 +122,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -140,6 +143,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*rtconutc$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('mrt') }
@@ -201,6 +205,21 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_content('') }
             end
           end
+        end
+      end
+
+      context 'hwtimestamps as hash' do
+        let(:params) do
+          {
+            hwtimestamps: { 'eth0' => ['minpoll 1', 'maxpoll 7'] },
+          }
+        end
+
+        case facts[:osfamily]
+        when 'Archlinux', 'Redhat'
+          it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
+        when 'Debian'
+          it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
         end
       end
 

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -31,6 +31,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
             it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0644') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_group('0') }
@@ -45,6 +46,7 @@ describe 'chrony' do
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
             it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0640') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_group('chrony') }
@@ -59,6 +61,7 @@ describe 'chrony' do
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
+            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0640') }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('0') }
@@ -87,6 +90,7 @@ describe 'chrony' do
             smoothtime: '400 0.001 leaponly',
             rtconutc: true,
             hwtimestamps: ['eth0'],
+            driftfile: '/var/tmp/chrony.drift',
           }
         end
 
@@ -101,6 +105,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -123,6 +128,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -144,6 +150,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*rtconutc$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('mrt') }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -32,6 +32,7 @@ describe 'chrony' do
             end
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtcsync$}) }
             it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0644') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_group('0') }
@@ -47,6 +48,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtcsync$}) }
             it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0640') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony.keys').with_group('chrony') }
@@ -62,6 +64,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
+            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*rtcsync$}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0640') }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('0') }
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('0') }
@@ -91,6 +94,7 @@ describe 'chrony' do
             rtconutc: true,
             hwtimestamps: ['eth0'],
             driftfile: '/var/tmp/chrony.drift',
+            rtcsync: false,
           }
         end
 
@@ -106,6 +110,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*rtcsync$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -129,6 +134,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*rtcsync$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -151,6 +157,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*rtconutc$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').without_content(%r{^\s*rtcsync$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('mrt') }

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -16,7 +16,7 @@ stratumweight <%= $chrony::stratumweight %>
 <% } -%>
 
 # Record the rate at which the system clock gains/losses time.
-driftfile /var/lib/chrony/drift
+driftfile <%= $chrony::driftfile %>
 
 # Enable kernel RTC synchronization.
 rtcsync

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -17,9 +17,11 @@ stratumweight <%= $chrony::stratumweight %>
 
 # Record the rate at which the system clock gains/losses time.
 driftfile <%= $chrony::driftfile %>
+<% if $chrony::rtcsync { -%>
 
 # Enable kernel RTC synchronization.
 rtcsync
+<% } -%>
 <% if $chrony::makestep_seconds and $chrony::makestep_updates { -%>
 
 # In first <%= $chrony::makestep_updates %> updates step the system clock instead of slew

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -61,6 +61,12 @@ local stratum <%= $chrony::local_stratum %>
 
 keyfile <%= $chrony::config_keys %>
 <% } -%>
+<% if $chrony::dumpdir { -%>
+
+# Save the measurement history for the servers to files on exit.
+dumponexit
+dumpdir <%= $chrony::dumpdir %>
+<% } -%>
 <% if ! $chrony::clientlog { -%>
 
 # Disable logging of client accesses.

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -120,3 +120,12 @@ smoothtime <%= $chrony::smoothtime %>
 # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#rtconutc
 rtconutc
 <% } -%>
+<% if ! $chrony::hwtimestamps.empty { -%>
+
+# Enable hardware timestamping of NTP packets sent to and received from the specified
+# network interface. If the specified interface is *, chronyd will try to enable HW
+# timestamping on all available interfaces.
+<%   $chrony::hwtimestamps.each |$interface| { -%>
+hwtimestamp <%= $interface.flatten.join(' ') %>
+<%   } -%>
+<% } -%>


### PR DESCRIPTION
The params added with this PR are:
driftfile, hwtimestamps, rtcsync, and dumpdir. Each with it's separate commit.