### PR TITLE
Remove unnecessary test on $service_ensure

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,10 +7,6 @@ class chrony::service (
   $service_manage = $chrony::service_manage,
   $service_name   = $chrony::service_name,
 ) inherits chrony {
-  unless $service_ensure in ['running', 'stopped'] {
-    fail('service_ensure parameter must be running or stopped')
-  }
-
   if $service_manage {
     service { $service_name:
       ensure     => $service_ensure,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,12 +9,8 @@ class chrony::service (
 ) inherits chrony {
   if $service_manage {
     service { $service_name:
-      ensure     => $service_ensure,
-      enable     => $service_enable,
-      name       => $service_name,
-      hasstatus  => true,
-      hasrestart => true,
+      ensure => $service_ensure,
+      enable => $service_enable,
     }
   }
-
 }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -280,8 +280,6 @@ describe 'chrony' do
               is_expected.to contain_service('chrony').with(
                 ensure: 'running',
                 enable: true,
-                hasstatus: true,
-                hasrestart: true,
               )
             end
           end
@@ -291,8 +289,6 @@ describe 'chrony' do
               is_expected.to contain_service('chronyd').with(
                 ensure: 'running',
                 enable: true,
-                hasstatus: true,
-                hasrestart: true,
               )
             end
           end
@@ -302,8 +298,6 @@ describe 'chrony' do
               is_expected.to contain_service('chrony').with(
                 ensure: 'running',
                 enable: true,
-                hasstatus: true,
-                hasrestart: true,
               )
             end
           end


### PR DESCRIPTION
$service_ensure is required by init.pp to have type Stdlib::Ensure::Service, so there is
no need for this test.