### PR TITLE
Restructure tests

### DIFF
--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -26,20 +26,27 @@ describe 'chrony' do
         case facts[:osfamily]
         when 'Archlinux'
           context 'using defaults' do
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 127\.0\.0\.1$}) }
-            ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
+            it do
+              is_expected.to contain_file('/etc/chrony.conf')
+                .with_content(%r{^\s*cmdallow 127\.0\.0\.1$})
+                .with_content(%r{^\s*server 0.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 1.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 2.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 3.pool.ntp.org iburst$})
+                .with_content(%r{^\s*rtconutc$})
+                .with_content(%r{^\s*driftfile /var/lib/chrony/drift$})
+                .with_content(%r{^\s*rtcsync$})
+                .with_content(%r{^\s*dumpdir /var/lib/chrony$})
+                .without_content(%r{^\s*\n\s*$})
             end
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtcsync$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/lib/chrony$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*\n\s*$}) }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0644') }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_group('0') }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_replace(true) }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_content("0 xyzzy\n") }
+            it do
+              is_expected.to contain_file('/etc/chrony.keys')
+                .with_mode('0644')
+                .with_owner('0')
+                .with_group('0')
+                .with_replace(true)
+                .with_content("0 xyzzy\n")
+            end
           end
         when 'Gentoo'
           context 'using defaults' do
@@ -67,39 +74,53 @@ describe 'chrony' do
           end
         when 'RedHat'
           context 'using defaults' do
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
-            it { is_expected.not_to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow.*$}) }
-            ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
+            it do
+              is_expected.to contain_file('/etc/chrony.conf')
+                .with_content(%r{^\s*bindcmdaddress ::1$})
+                .with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$})
+                .without_content(%r{^\s*cmdallow.*$})
+                .with_content(%r{^\s*server 0.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 1.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 2.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 3.pool.ntp.org iburst$})
+                .with_content(%r{^\s*driftfile /var/lib/chrony/drift$})
+                .with_content(%r{^\s*rtcsync$})
+                .without_content(%r{^\s*dumpdir})
+                .without_content(%r{^\s*\n\s*$})
             end
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtcsync$}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*dumpdir}) }
-            it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*\n\s*$}) }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0640') }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_owner('0') }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_group('chrony') }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_replace(true) }
-            it { is_expected.to contain_file('/etc/chrony.keys').with_content("0 xyzzy\n") }
+            it do
+              is_expected.to contain_file('/etc/chrony.keys')
+                .with_mode('0640')
+                .with_owner('0')
+                .with_group('chrony')
+                .with_replace(true)
+                .with_content("0 xyzzy\n")
+            end
           end
         when 'Debian'
           context 'using defaults' do
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
-            it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow.*$}) }
-            ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
+            it do
+              is_expected.to contain_file('/etc/chrony/chrony.conf')
+                .with_content(%r{^\s*bindcmdaddress ::1$})
+                .with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$})
+                .without_content(%r{^\s*cmdallow.*$})
+                .with_content(%r{^\s*server 0.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 1.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 2.pool.ntp.org iburst$})
+                .with_content(%r{^\s*server 3.pool.ntp.org iburst$})
+                .with_content(%r{^\s*driftfile /var/lib/chrony/drift$})
+                .with_content(%r{^\s*rtcsync$})
+                .without_content(%r{^\s*dumpdir})
+                .without_content(%r{^\s*\n\s*$})
             end
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*rtcsync$}) }
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').without_content(%r{^\s*dumpdir}) }
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').without_content(%r{^\s*\n\s*$}) }
-            it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0640') }
-            it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('0') }
-            it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('0') }
-            it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_replace(true) }
-            it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_content("0 xyzzy\n") }
+            it do
+              is_expected.to contain_file('/etc/chrony/chrony.keys')
+                .with_mode('0640')
+                .with_owner('0')
+                .with_group('0')
+                .with_replace(true)
+                .with_content("0 xyzzy\n")
+            end
           end
         end
       end
@@ -133,70 +154,87 @@ describe 'chrony' do
           case facts[:osfamily]
           when 'Archinux'
             context 'with some params passed in' do
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*rtcsync$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/tmp$}) }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_replace(true) }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_content("0 sunny\n") }
+              it do
+                is_expected.to contain_file('/etc/chrony.conf')
+                  .with_content(%r{^\s*port 123$})
+                  .with_content(%r{^s*allow 192\.168\/16$})
+                  .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
+                  .with_content(%r{^\s*cmddeny 1\.2\.3$})
+                  .with_content(%r{^\s*cmdallow all 1\.2$})
+                  .with_content(%r{^\s*rtconutc$})
+                  .with_content(%r{^\s*hwtimestamp eth0$})
+                  .with_content(%r{^\s*driftfile /var/tmp/chrony.drift$})
+                  .without_content(%r{^\s*rtcsync$})
+                  .with_content(%r{^\s*dumpdir /var/tmp$})
+              end
+              it do
+                is_expected.to contain_file('/etc/chrony.keys')
+                  .with_mode('0123')
+                  .with_owner('steve')
+                  .with_group('mrt')
+                  .with_replace(true)
+                  .with_content("0 sunny\n")
+              end
             end
           when 'RedHat'
             context 'with some params passed in' do
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*leapsecmode slew$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*leapsectz right/UTC$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*maxslewrate 1000\.0$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
-
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*rtcsync$}) }
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*dumpdir /var/tmp$}) }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_replace(true) }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_content("0 sunny\n") }
+              it do
+                is_expected.to contain_file('/etc/chrony.conf')
+                  .with_content(%r{^\s*leapsecmode slew$})
+                  .with_content(%r{^\s*leapsectz right/UTC$})
+                  .with_content(%r{^\s*maxslewrate 1000\.0$})
+                  .with_content(%r{^\s*smoothtime 400 0\.001 leaponly$})
+                  .with_content(%r{^\s*port 123$})
+                  .with_content(%r{^\s*cmdport 257$})
+                  .with_content(%r{^s*allow 192\.168\/16$})
+                  .with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$})
+                  .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
+                  .with_content(%r{^\s*cmddeny 1\.2\.3$})
+                  .with_content(%r{^\s*cmdallow all 1\.2$})
+                  .with_content(%r{^\s*rtconutc$})
+                  .with_content(%r{^\s*hwtimestamp eth0$})
+                  .with_content(%r{^\s*driftfile /var/tmp/chrony.drift$})
+                  .without_content(%r{^\s*rtcsync$})
+                  .with_content(%r{^\s*dumpdir /var/tmp$})
+              end
+              it do
+                is_expected.to contain_file('/etc/chrony.keys')
+                  .with_mode('0123')
+                  .with_owner('steve')
+                  .with_group('mrt')
+                  .with_replace(true)
+                  .with_content("0 sunny\n")
+              end
             end
           when 'Debian', 'Gentoo'
             context 'with some params passed in' do
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*leapsectz right/UTC$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*leapsecmode slew$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*maxslewrate 1000\.0$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*rtconutc$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').without_content(%r{^\s*rtcsync$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*dumpdir /var/tmp$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0123') }
-              it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('steve') }
-              it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('mrt') }
-              it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_replace(true) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_content("0 sunny\n") }
+              it do
+                is_expected.to contain_file('/etc/chrony/chrony.conf')
+                  .with_content(%r{^\s*leapsectz right/UTC$})
+                  .with_content(%r{^\s*leapsecmode slew$})
+                  .with_content(%r{^\s*maxslewrate 1000\.0$})
+                  .with_content(%r{^\s*smoothtime 400 0\.001 leaponly$})
+                  .with_content(%r{^\s*port 123$})
+                  .with_content(%r{^\s*cmdport 257$})
+                  .with_content(%r{^s*allow 192\.168\/16$})
+                  .with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$})
+                  .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
+                  .with_content(%r{^\s*cmddeny 1\.2\.3$})
+                  .with_content(%r{^\s*cmdallow all 1\.2$})
+                  .with_content(%r{^\s*rtconutc$})
+                  .with_content(%r{^\s*hwtimestamp eth0$})
+                  .with_content(%r{^\s*driftfile /var/tmp/chrony.drift$})
+                  .without_content(%r{^\s*rtcsync$})
+                  .with_content(%r{^\s*dumpdir /var/tmp$})
+              end
+              it do
+                is_expected.to contain_file('/etc/chrony/chrony.keys')
+                  .with_mode('0123')
+                  .with_owner('steve')
+                  .with_group('mrt')
+                  .with_replace(true)
+                  .with_content("0 sunny\n")
+              end
             end
           end
         end

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -6,6 +6,22 @@ describe 'chrony' do
       let(:facts) do
         facts
       end
+      let(:config_file) do
+        case facts[:osfamily]
+        when 'Archlinux', 'RedHat', 'Suse'
+          '/etc/chrony.conf'
+        else
+          '/etc/chrony/chrony.conf'
+        end
+      end
+      let(:keys_file) do
+        case facts[:osfamily]
+        when 'Archlinux', 'RedHat', 'Suse'
+          '/etc/chrony.keys'
+        else
+          '/etc/chrony/chrony.keys'
+        end
+      end
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -167,103 +167,40 @@ describe 'chrony' do
         end
 
         context 'chrony::config' do
-          case facts[:osfamily]
-          when 'Archinux'
-            context 'with some params passed in' do
-              it do
-                is_expected.to contain_file(config_file)
-                  .with_content(%r{^\s*port 123$})
-                  .with_content(%r{^s*allow 192\.168\/16$})
-                  .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
-                  .with_content(%r{^\s*cmddeny 1\.2\.3$})
-                  .with_content(%r{^\s*cmdallow all 1\.2$})
-                  .with_content(%r{^\s*rtconutc$})
-                  .with_content(%r{^\s*hwtimestamp eth0$})
-                  .with_content(%r{^\s*driftfile /var/tmp/chrony.drift$})
-                  .without_content(%r{^\s*rtcsync$})
-                  .with_content(%r{^\s*dumpdir /var/tmp$})
-              end
-              it do
-                is_expected.to contain_file(keys_file)
-                  .with_mode('0123')
-                  .with_owner('steve')
-                  .with_group('mrt')
-                  .with_replace(true)
-                  .with_content("0 sunny\n")
-              end
-            end
-          when 'RedHat'
-            context 'with some params passed in' do
-              it do
-                is_expected.to contain_file(config_file)
-                  .with_content(%r{^\s*leapsecmode slew$})
-                  .with_content(%r{^\s*leapsectz right/UTC$})
-                  .with_content(%r{^\s*maxslewrate 1000\.0$})
-                  .with_content(%r{^\s*smoothtime 400 0\.001 leaponly$})
-                  .with_content(%r{^\s*port 123$})
-                  .with_content(%r{^\s*cmdport 257$})
-                  .with_content(%r{^s*allow 192\.168\/16$})
-                  .with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$})
-                  .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
-                  .with_content(%r{^\s*cmddeny 1\.2\.3$})
-                  .with_content(%r{^\s*cmdallow all 1\.2$})
-                  .with_content(%r{^\s*rtconutc$})
-                  .with_content(%r{^\s*hwtimestamp eth0$})
-                  .with_content(%r{^\s*driftfile /var/tmp/chrony.drift$})
-                  .without_content(%r{^\s*rtcsync$})
-                  .with_content(%r{^\s*dumpdir /var/tmp$})
-              end
-              it do
-                is_expected.to contain_file(keys_file)
-                  .with_mode('0123')
-                  .with_owner('steve')
-                  .with_group('mrt')
-                  .with_replace(true)
-                  .with_content("0 sunny\n")
-              end
-            end
-          when 'Debian', 'Gentoo'
-            context 'with some params passed in' do
-              it do
-                is_expected.to contain_file(config_file)
-                  .with_content(%r{^\s*leapsectz right/UTC$})
-                  .with_content(%r{^\s*leapsecmode slew$})
-                  .with_content(%r{^\s*maxslewrate 1000\.0$})
-                  .with_content(%r{^\s*smoothtime 400 0\.001 leaponly$})
-                  .with_content(%r{^\s*port 123$})
-                  .with_content(%r{^\s*cmdport 257$})
-                  .with_content(%r{^s*allow 192\.168\/16$})
-                  .with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$})
-                  .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
-                  .with_content(%r{^\s*cmddeny 1\.2\.3$})
-                  .with_content(%r{^\s*cmdallow all 1\.2$})
-                  .with_content(%r{^\s*rtconutc$})
-                  .with_content(%r{^\s*hwtimestamp eth0$})
-                  .with_content(%r{^\s*driftfile /var/tmp/chrony.drift$})
-                  .without_content(%r{^\s*rtcsync$})
-                  .with_content(%r{^\s*dumpdir /var/tmp$})
-              end
-              it do
-                is_expected.to contain_file(keys_file)
-                  .with_mode('0123')
-                  .with_owner('steve')
-                  .with_group('mrt')
-                  .with_replace(true)
-                  .with_content("0 sunny\n")
-              end
-            end
+          it do
+            is_expected.to contain_file(config_file)
+              .with_content(%r{^\s*leapsecmode slew$})
+              .with_content(%r{^\s*leapsectz right/UTC$})
+              .with_content(%r{^\s*leapsecmode slew$})
+              .with_content(%r{^\s*maxslewrate 1000\.0$})
+              .with_content(%r{^\s*smoothtime 400 0\.001 leaponly$})
+              .with_content(%r{^\s*port 123$})
+              .with_content(%r{^\s*cmdport 257$})
+              .with_content(%r{^s*allow 192\.168\/16$})
+              .with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$})
+              .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
+              .with_content(%r{^\s*cmddeny 1\.2\.3$})
+              .with_content(%r{^\s*cmdallow all 1\.2$})
+              .with_content(%r{^\s*rtconutc$})
+              .with_content(%r{^\s*hwtimestamp eth0$})
+              .with_content(%r{^\s*driftfile /var/tmp/chrony.drift$})
+              .without_content(%r{^\s*rtcsync$})
+              .with_content(%r{^\s*dumpdir /var/tmp$})
+          end
+          it do
+            is_expected.to contain_file(keys_file)
+              .with_mode('0123')
+              .with_owner('steve')
+              .with_group('mrt')
+              .with_replace(true)
+              .with_content("0 sunny\n")
           end
         end
       end
 
       describe 'stratumweight' do
         context 'by default' do
-          case facts[:osfamily]
-          when 'Archlinux', 'RedHat'
-            it { is_expected.not_to contain_file(config_file).with_content(%r{stratumweight}) }
-          when 'Debian', 'Gentoo'
-            it { is_expected.not_to contain_file(config_file).with_content(%r{stratumweight}) }
-          end
+          it { is_expected.not_to contain_file(config_file).with_content(%r{stratumweight}) }
         end
         context 'when set' do
           let(:params) do
@@ -272,12 +209,7 @@ describe 'chrony' do
             }
           end
 
-          case facts[:osfamily]
-          when 'Archlinux', 'RedHat'
-            it { is_expected.to contain_file(config_file).with_content(%r{^stratumweight 0$}) }
-          when 'Debian', 'Gentoo'
-            it { is_expected.to contain_file(config_file).with_content(%r{^stratumweight 0$}) }
-          end
+          it { is_expected.to contain_file(config_file).with_content(%r{^stratumweight 0$}) }
         end
       end
 
@@ -289,25 +221,8 @@ describe 'chrony' do
           }
         end
 
-        context 'chrony::config' do
-          case facts[:osfamily]
-          when 'Archlinux'
-            context 'unmanaged chrony.keys file' do
-              it { is_expected.to contain_file(keys_file).with_replace(false) }
-              it { is_expected.to contain_file(keys_file).with_content('') }
-            end
-          when 'RedHat'
-            context 'unmanaged chrony.keys file' do
-              it { is_expected.to contain_file(keys_file).with_replace(false) }
-              it { is_expected.to contain_file(keys_file).with_content('') }
-            end
-          when 'Debian', 'Gentoo'
-            context 'unmanaged chrony.keys file' do
-              it { is_expected.to contain_file(keys_file).with_replace(false) }
-              it { is_expected.to contain_file(keys_file).with_content('') }
-            end
-          end
-        end
+        it { is_expected.to contain_file(keys_file).with_replace(false) }
+        it { is_expected.to contain_file(keys_file).with_content('') }
       end
 
       context 'hwtimestamps as hash' do
@@ -317,12 +232,7 @@ describe 'chrony' do
           }
         end
 
-        case facts[:osfamily]
-        when 'Archlinux', 'Redhat'
-          it { is_expected.to contain_file(config_file).with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
-        when 'Debian', 'Gentoo'
-          it { is_expected.to contain_file(config_file).with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
-        end
+        it { is_expected.to contain_file(config_file).with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
       end
 
       context 'unmanaged chrony.keys file and password' do

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -43,7 +43,7 @@ describe 'chrony' do
         when 'Archlinux'
           context 'using defaults' do
             it do
-              is_expected.to contain_file('/etc/chrony.conf')
+              is_expected.to contain_file(config_file)
                 .with_content(%r{^\s*cmdallow 127\.0\.0\.1$})
                 .with_content(%r{^\s*server 0.pool.ntp.org iburst$})
                 .with_content(%r{^\s*server 1.pool.ntp.org iburst$})
@@ -56,7 +56,7 @@ describe 'chrony' do
                 .without_content(%r{^\s*\n\s*$})
             end
             it do
-              is_expected.to contain_file('/etc/chrony.keys')
+              is_expected.to contain_file(keys_file)
                 .with_mode('0644')
                 .with_owner('0')
                 .with_group('0')
@@ -67,7 +67,7 @@ describe 'chrony' do
         when 'Gentoo'
           context 'using defaults' do
             it do
-              is_expected.to contain_file('/etc/chrony/chrony.conf')
+              is_expected.to contain_file(config_file)
                 .without_content(%r{^\s*cmdallow})
                 .with_content(%r{^\s*server 0.pool.ntp.org iburst$})
                 .with_content(%r{^\s*server 1.pool.ntp.org iburst$})
@@ -80,7 +80,7 @@ describe 'chrony' do
                 .without_content(%r{^\s*\n\s*$})
             end
             it do
-              is_expected.to contain_file('/etc/chrony/chrony.keys')
+              is_expected.to contain_file(keys_file)
                 .with_mode('0644')
                 .with_owner('0')
                 .with_group('0')
@@ -91,7 +91,7 @@ describe 'chrony' do
         when 'RedHat'
           context 'using defaults' do
             it do
-              is_expected.to contain_file('/etc/chrony.conf')
+              is_expected.to contain_file(config_file)
                 .with_content(%r{^\s*bindcmdaddress ::1$})
                 .with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$})
                 .without_content(%r{^\s*cmdallow.*$})
@@ -105,7 +105,7 @@ describe 'chrony' do
                 .without_content(%r{^\s*\n\s*$})
             end
             it do
-              is_expected.to contain_file('/etc/chrony.keys')
+              is_expected.to contain_file(keys_file)
                 .with_mode('0640')
                 .with_owner('0')
                 .with_group('chrony')
@@ -116,7 +116,7 @@ describe 'chrony' do
         when 'Debian'
           context 'using defaults' do
             it do
-              is_expected.to contain_file('/etc/chrony/chrony.conf')
+              is_expected.to contain_file(config_file)
                 .with_content(%r{^\s*bindcmdaddress ::1$})
                 .with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$})
                 .without_content(%r{^\s*cmdallow.*$})
@@ -130,7 +130,7 @@ describe 'chrony' do
                 .without_content(%r{^\s*\n\s*$})
             end
             it do
-              is_expected.to contain_file('/etc/chrony/chrony.keys')
+              is_expected.to contain_file(keys_file)
                 .with_mode('0640')
                 .with_owner('0')
                 .with_group('0')
@@ -171,7 +171,7 @@ describe 'chrony' do
           when 'Archinux'
             context 'with some params passed in' do
               it do
-                is_expected.to contain_file('/etc/chrony.conf')
+                is_expected.to contain_file(config_file)
                   .with_content(%r{^\s*port 123$})
                   .with_content(%r{^s*allow 192\.168\/16$})
                   .with_content(%r{^\s*cmdallow 1\.2\.3\.4$})
@@ -184,7 +184,7 @@ describe 'chrony' do
                   .with_content(%r{^\s*dumpdir /var/tmp$})
               end
               it do
-                is_expected.to contain_file('/etc/chrony.keys')
+                is_expected.to contain_file(keys_file)
                   .with_mode('0123')
                   .with_owner('steve')
                   .with_group('mrt')
@@ -195,7 +195,7 @@ describe 'chrony' do
           when 'RedHat'
             context 'with some params passed in' do
               it do
-                is_expected.to contain_file('/etc/chrony.conf')
+                is_expected.to contain_file(config_file)
                   .with_content(%r{^\s*leapsecmode slew$})
                   .with_content(%r{^\s*leapsectz right/UTC$})
                   .with_content(%r{^\s*maxslewrate 1000\.0$})
@@ -214,7 +214,7 @@ describe 'chrony' do
                   .with_content(%r{^\s*dumpdir /var/tmp$})
               end
               it do
-                is_expected.to contain_file('/etc/chrony.keys')
+                is_expected.to contain_file(keys_file)
                   .with_mode('0123')
                   .with_owner('steve')
                   .with_group('mrt')
@@ -225,7 +225,7 @@ describe 'chrony' do
           when 'Debian', 'Gentoo'
             context 'with some params passed in' do
               it do
-                is_expected.to contain_file('/etc/chrony/chrony.conf')
+                is_expected.to contain_file(config_file)
                   .with_content(%r{^\s*leapsectz right/UTC$})
                   .with_content(%r{^\s*leapsecmode slew$})
                   .with_content(%r{^\s*maxslewrate 1000\.0$})
@@ -244,7 +244,7 @@ describe 'chrony' do
                   .with_content(%r{^\s*dumpdir /var/tmp$})
               end
               it do
-                is_expected.to contain_file('/etc/chrony/chrony.keys')
+                is_expected.to contain_file(keys_file)
                   .with_mode('0123')
                   .with_owner('steve')
                   .with_group('mrt')
@@ -260,9 +260,9 @@ describe 'chrony' do
         context 'by default' do
           case facts[:osfamily]
           when 'Archlinux', 'RedHat'
-            it { is_expected.not_to contain_file('/etc/chrony.conf').with_content(%r{stratumweight}) }
+            it { is_expected.not_to contain_file(config_file).with_content(%r{stratumweight}) }
           when 'Debian', 'Gentoo'
-            it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{stratumweight}) }
+            it { is_expected.not_to contain_file(config_file).with_content(%r{stratumweight}) }
           end
         end
         context 'when set' do
@@ -274,9 +274,9 @@ describe 'chrony' do
 
           case facts[:osfamily]
           when 'Archlinux', 'RedHat'
-            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^stratumweight 0$}) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^stratumweight 0$}) }
           when 'Debian', 'Gentoo'
-            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^stratumweight 0$}) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^stratumweight 0$}) }
           end
         end
       end
@@ -293,18 +293,18 @@ describe 'chrony' do
           case facts[:osfamily]
           when 'Archlinux'
             context 'unmanaged chrony.keys file' do
-              it { is_expected.to contain_file('/etc/chrony.keys').with_replace(false) }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_content('') }
+              it { is_expected.to contain_file(keys_file).with_replace(false) }
+              it { is_expected.to contain_file(keys_file).with_content('') }
             end
           when 'RedHat'
             context 'unmanaged chrony.keys file' do
-              it { is_expected.to contain_file('/etc/chrony.keys').with_replace(false) }
-              it { is_expected.to contain_file('/etc/chrony.keys').with_content('') }
+              it { is_expected.to contain_file(keys_file).with_replace(false) }
+              it { is_expected.to contain_file(keys_file).with_content('') }
             end
           when 'Debian', 'Gentoo'
             context 'unmanaged chrony.keys file' do
-              it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_replace(false) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_content('') }
+              it { is_expected.to contain_file(keys_file).with_replace(false) }
+              it { is_expected.to contain_file(keys_file).with_content('') }
             end
           end
         end
@@ -319,9 +319,9 @@ describe 'chrony' do
 
         case facts[:osfamily]
         when 'Archlinux', 'Redhat'
-          it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
+          it { is_expected.to contain_file(config_file).with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
         when 'Debian', 'Gentoo'
-          it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
+          it { is_expected.to contain_file(config_file).with_content(%r{^\s*hwtimestamp eth0 minpoll 1 maxpoll 7$}) }
         end
       end
 


### PR DESCRIPTION
Replace multiple is_expected.to contain_file() for the same file with a single
is_expected.to contain_file() with instead multiple .with_content() or .without_content()
for improved readability and preformance.