### PR TITLE
Fix template to not add trailing space after servers,peers,pools

### DIFF
--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -1,12 +1,12 @@
 # NTP servers
 <% $chrony::servers.each |$server| { -%>
-server <%= $server.flatten.join(' ') %>
+server <%= $server.flatten.filter |$value| { $value != undef }.join(' ') %>
 <% } -%>
 <% $chrony::pools.each |$pool| { -%>
-pool <%= $pool.flatten.join(' ') %>
+pool <%= $pool.flatten.filter |$value| { $value != undef }.join(' ') %>
 <% } -%>
 <% $chrony::peers.each |$peer| { -%>
-peer <%= $peer.flatten.join(' ') %>
+peer <%= $peer.flatten.filter |$value| { $value != undef }.join(' ') %>
 <% } -%>
 <% if $chrony::stratumweight { -%>
 


### PR DESCRIPTION
The attempt to simplify the template by letting flatten() take care of the different
allowed data-types for servers,peers, and pools, was unfortunately a bit too
optimistic. The result was that join(' ') on a Array with empty element created a extra
space caracter when $chrony::servers was a hash with a key but no value.