### PR TITLE
queryhosts: enforce Array[String] data type

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "jpogran.puppet-vscode",
-    "rebornix.Ruby"
-  ]
-}

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -369,7 +369,7 @@ Default value: `3`
 
 ##### `queryhosts`
 
-Data type: `Any`
+Data type: `Array[String]`
 
 This adds the networks, hosts that are allowed to query the daemon.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -211,7 +211,7 @@ class chrony (
   Variant[Hash,Array[Stdlib::Fqdn]] $pools                         = {},
   Numeric $makestep_seconds                                        = 10,
   Integer $makestep_updates                                        = 3,
-  $queryhosts                                                      = [],
+  Array[String] $queryhosts                                        = [],
   Optional[String[1]] $mailonchange                                = undef,
   Float $threshold                                                 = 0.5,
   Boolean $lock_all                                                = false,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -141,7 +141,7 @@ describe 'chrony' do
 
         context 'chrony::config' do
           case facts[:os]['family']
-          when 'Archinux'
+          when 'Archlinux'
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }


### PR DESCRIPTION
The conversion from ERB to EPP in #79 changed the behavior of queryhosts slightly. Before, setting queryhosts to the empty string worked for configuring chrony to allow any query. After, empty string is considered empty, so the "allow" directive would not be rendered.

Enforcing the data type ensures that people upgrading this module who have been using empty string get an error rather than a valid but misconfigured chrony.conf. The replacement for empty string is an array with a single empty string element: ['']

Also, fixing a typo in the tests.

I also removed an obsolete vscode extensions.json (the puppet extension name is obsolete). I have the whole .vscode directory git-ignored, so `bundle exec rake test` aborts when it sees that something ignored exists in the repository. I don't think we really need this file.