### PR TITLE
Restore behaviour of `servers` and `pools` parameters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -297,10 +297,10 @@ Default value: ``undef``
 
 ##### `peers`
 
-Data type: `Any`
+Data type: `Variant[Hash,Array[Stdlib::Host]]`
 
 This selects the servers to use for NTP peers (symmetric association).
-It is an array of servers.
+It can be an array of peers or a hash of peers with their respective options.
 
 Default value: `[]`
 
@@ -309,7 +309,8 @@ Default value: `[]`
 Data type: `Variant[Hash,Array[Stdlib::Host]]`
 
 This selects the servers to use for NTP servers.  It can be an array of servers
-or a hash of servers to their respective options.
+or a hash of servers to their respective options. If an array is used, `iburst` will be configured for each server.
+If you don't want to use `iburst`, use a hash instead.
 
 Default value: `{
     '0.pool.ntp.org' => ['iburst'],
@@ -323,7 +324,7 @@ Default value: `{
 Data type: `Variant[Hash,Array[Stdlib::Fqdn]]`
 
 This is used to specify one or more *pools* of NTP servers to use instead of individual NTP servers.
-Similar to [`server`](#server), it can be an array of pools or a hash of pools to their respective options.
+Similar to [`server`](#server), it can be an array of pools, (using iburst), or a hash of pools to their respective options.
 See [pool](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#pool)
 
 Default value: `{}`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -28,7 +28,7 @@
 
 ### Data types
 
-* [`Chrony::Servers`](#chronyservers)
+* [`Chrony::Servers`](#chronyservers): Type for the `servers`, `pools` and `peers` parameters.
 
 ## Classes
 
@@ -47,11 +47,22 @@ Installs and configures chrony
 include chrony
 ```
 
-##### Use specific servers
+##### Use specific servers (These will be configured with the `iburst` option.)
 
 ```puppet
 class { 'chrony':
   servers => [ 'ntp1.corp.com', 'ntp2.corp.com', ],
+}
+```
+
+##### Two specific servers without `iburst`
+
+```puppet
+class { 'chrony':
+  servers => {
+    'ntp1.corp.com' => [],
+    'ntp2.corp.com' => [],
+  },
 }
 ```
 
@@ -546,7 +557,34 @@ Default value: `$chrony::params::dumpdir`
 
 ### `Chrony::Servers`
 
-The Chrony::Servers data type.
+This type is for the `servers`, `pools` and `peers` parameters.
+
+#### Examples
+
+##### A hash of servers
+
+```puppet
+{
+  'ntp1.example.com => [
+    'minpoll 3',
+    'maxpoll 6',
+  ],
+  'ntp2.example.com => [
+    'iburst',
+    'minpoll 4',
+    'maxpoll 8',
+  ],
+}
+```
+
+##### An array of servers
+
+```puppet
+[
+  'ntp1.example.com',
+  'ntp2.example.com',
+]
+```
 
 Alias of `Variant[Hash[Stdlib::Host, Optional[Array[String]]], Array[Stdlib::Host]]`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -17,6 +17,15 @@
 * `chrony::params`: chrony class parameters
 * `chrony::service`: Manages the chrony service
 
+### Functions
+
+#### Public Functions
+
+
+#### Private Functions
+
+* `chrony::server_array_to_hash`: Function to normalise servers/pools/peers
+
 ## Classes
 
 ### `chrony`
@@ -526,4 +535,6 @@ Data type: `Optional[Stdlib::Unixpath]`
 Directory to store measurement history in on exit.
 
 Default value: `$chrony::params::dumpdir`
+
+## Functions
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -26,6 +26,10 @@
 
 * `chrony::server_array_to_hash`: Function to normalise servers/pools/peers
 
+### Data types
+
+* [`Chrony::Servers`](#chronyservers)
+
 ## Classes
 
 ### `chrony`
@@ -306,7 +310,7 @@ Default value: ``undef``
 
 ##### `peers`
 
-Data type: `Variant[Hash,Array[Stdlib::Host]]`
+Data type: `Chrony::Servers`
 
 This selects the servers to use for NTP peers (symmetric association).
 It can be an array of peers or a hash of peers with their respective options.
@@ -315,7 +319,7 @@ Default value: `[]`
 
 ##### `servers`
 
-Data type: `Variant[Hash,Array[Stdlib::Host]]`
+Data type: `Chrony::Servers`
 
 This selects the servers to use for NTP servers.  It can be an array of servers
 or a hash of servers to their respective options. If an array is used, `iburst` will be configured for each server.
@@ -330,7 +334,7 @@ Default value: `{
 
 ##### `pools`
 
-Data type: `Variant[Hash,Array[Stdlib::Fqdn]]`
+Data type: `Chrony::Servers`
 
 This is used to specify one or more *pools* of NTP servers to use instead of individual NTP servers.
 Similar to [`server`](#server), it can be an array of pools, (using iburst), or a hash of pools to their respective options.
@@ -537,4 +541,12 @@ Directory to store measurement history in on exit.
 Default value: `$chrony::params::dumpdir`
 
 ## Functions
+
+## Data types
+
+### `Chrony::Servers`
+
+The Chrony::Servers data type.
+
+Alias of `Variant[Hash[Stdlib::Host, Optional[Array[String]]], Array[Stdlib::Host]]`
 

--- a/functions/server_array_to_hash.pp
+++ b/functions/server_array_to_hash.pp
@@ -1,0 +1,12 @@
+# @summary Function to normalise servers/pools/peers
+#
+# @api private
+function chrony::server_array_to_hash(Variant[Hash,Array] $servers, $options = []) >> Hash {
+  if $servers.is_a(Hash) {
+    $servers
+  } else {
+    $servers.reduce({}) |$memo, $server| { # lint:ignore:manifest_whitespace_opening_brace_before
+      $memo + { $server => $options }
+    }
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,7 +43,13 @@ class chrony::config (
     owner   => 0,
     group   => 0,
     mode    => '0644',
-    content => epp($config_template),
+    content => epp($config_template,
+      {
+        servers => chrony::server_array_to_hash($servers, ['iburst']),
+        pools   => chrony::server_array_to_hash($pools, ['iburst']),
+        peers   => chrony::server_array_to_hash($peers),
+      }
+    ),
   }
 
   file { $config_keys:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,9 +2,16 @@
 #
 # @example Install chrony with default options
 #   include chrony
-# @example Use specific servers
+# @example Use specific servers (These will be configured with the `iburst` option.)
 #   class { 'chrony':
 #     servers => [ 'ntp1.corp.com', 'ntp2.corp.com', ],
+#   }
+# @example Two specific servers without `iburst`
+#   class { 'chrony':
+#     servers => {
+#       'ntp1.corp.com' => [],
+#       'ntp2.corp.com' => [],
+#     },
 #   }
 # @example Ensure a secret password is used for chronyc
 #   class { 'chrony':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,13 +104,14 @@
 #   Also see [`package_source`](#package_source).
 # @param peers
 #   This selects the servers to use for NTP peers (symmetric association).
-#   It is an array of servers.
+#   It can be an array of peers or a hash of peers with their respective options.
 # @param servers
 #   This selects the servers to use for NTP servers.  It can be an array of servers
-#   or a hash of servers to their respective options.
+#   or a hash of servers to their respective options. If an array is used, `iburst` will be configured for each server.
+#   If you don't want to use `iburst`, use a hash instead.
 # @param pools
 #   This is used to specify one or more *pools* of NTP servers to use instead of individual NTP servers.
-#   Similar to [`server`](#server), it can be an array of pools or a hash of pools to their respective options.
+#   Similar to [`server`](#server), it can be an array of pools, (using iburst), or a hash of pools to their respective options.
 #   See [pool](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#pool)
 # @param refclocks
 #   This should be a Hash of hardware reference clock drivers to use.  They hash
@@ -201,7 +202,7 @@ class chrony (
   Optional[String] $package_source                                 = undef,
   Optional[String] $package_provider                               = undef,
   $refclocks                                                       = [],
-  $peers                                                           = [],
+  Variant[Hash,Array[Stdlib::Host]] $peers                         = [],
   Variant[Hash,Array[Stdlib::Host]] $servers                       = {
     '0.pool.ntp.org' => ['iburst'],
     '1.pool.ntp.org' => ['iburst'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,14 +202,14 @@ class chrony (
   Optional[String] $package_source                                 = undef,
   Optional[String] $package_provider                               = undef,
   $refclocks                                                       = [],
-  Variant[Hash,Array[Stdlib::Host]] $peers                         = [],
-  Variant[Hash,Array[Stdlib::Host]] $servers                       = {
+  Chrony::Servers $peers                                           = [],
+  Chrony::Servers $servers                                         = {
     '0.pool.ntp.org' => ['iburst'],
     '1.pool.ntp.org' => ['iburst'],
     '2.pool.ntp.org' => ['iburst'],
     '3.pool.ntp.org' => ['iburst'],
   },
-  Variant[Hash,Array[Stdlib::Fqdn]] $pools                         = {},
+  Chrony::Servers $pools                                           = {},
   Numeric $makestep_seconds                                        = 10,
   Integer $makestep_updates                                        = 3,
   Array[String] $queryhosts                                        = [],

--- a/spec/type_aliases/servers_spec.rb
+++ b/spec/type_aliases/servers_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'Chrony::Servers' do
+  [
+    ['ntp1.example.com', 'ntp2.example.com'],
+    {
+      'ntp1.example.com' => [],
+      'ntp2.example.com' => ['maxpoll 6'],
+    },
+    {},
+    [],
+    {
+      'ntp1.example.com' => :undef
+    }
+  ].each do |value|
+    describe value.inspect do
+      it { is_expected.to allow_value(value) }
+    end
+  end
+end

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -1,12 +1,42 @@
 # NTP servers
+<% if $chrony::servers.is_a(Hash) { -%>
+<%   $chrony::servers.keys.sort.each |$server| { -%>
+<%     if $chrony::servers[$server] and !$chrony::servers[$server].empty { -%>
+server <%= $server %> <%= $chrony::servers[$server].join(' ') %>
+<% } else { -%>
+server <%= $server %>
+<% } -%>
+<% } -%>
+<% } else { -%>
 <% $chrony::servers.each |$server| { -%>
-server <%= $server.flatten.join(' ') %>
+server <%= $server %> iburst
 <% } -%>
+<% } -%>
+<% if $chrony::pools.is_a(Hash) { -%>
+<%   $chrony::pools.keys.sort.each |$pool| { -%>
+<%     if $chrony::pools[$pool] and !$chrony::pools[$pool].empty { -%>
+pool <%= $pool %> <%= $chrony::pools[$pool].join(' ') %>
+<% } else { -%>
+pool <%= $pool %>
+<% } -%>
+<% } -%>
+<% } else { -%>
 <% $chrony::pools.each |$pool| { -%>
-pool <%= $pool.flatten.join(' ') %>
+pool <%= $pool %> iburst
 <% } -%>
+<% } -%>
+<% if $chrony::peers.is_a(Hash) { -%>
+<%   $chrony::peers.keys.sort.each |$peer| { -%>
+<%     if $chrony::peers[$peer] and !$chrony::peers[$peer].empty { -%>
+peer <%= $peer %> <%= $chrony::peers[$peer].join(' ') %>
+<% } else { -%>
+peer <%= $peer %>
+<% } -%>
+<% } -%>
+<% } else { -%>
 <% $chrony::peers.each |$peer| { -%>
-peer <%= $peer.flatten.join(' ') %>
+peer <%= $peer %>
+<% } -%>
 <% } -%>
 <% if $chrony::stratumweight { -%>
 

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -1,42 +1,24 @@
 # NTP servers
-<% if $chrony::servers.is_a(Hash) { -%>
-<%   $chrony::servers.keys.sort.each |$server| { -%>
-<%     if $chrony::servers[$server] and !$chrony::servers[$server].empty { -%>
-server <%= $server %> <%= $chrony::servers[$server].join(' ') %>
-<% } else { -%>
+<% $servers.keys.sort.each |$server| { -%>
+<%   if $servers[$server].empty { -%>
 server <%= $server %>
+<%   } else { -%>
+server <%= $server %> <%= $servers[$server].join(' ') %>
+<%   } -%>
 <% } -%>
-<% } -%>
-<% } else { -%>
-<% $chrony::servers.each |$server| { -%>
-server <%= $server %> iburst
-<% } -%>
-<% } -%>
-<% if $chrony::pools.is_a(Hash) { -%>
-<%   $chrony::pools.keys.sort.each |$pool| { -%>
-<%     if $chrony::pools[$pool] and !$chrony::pools[$pool].empty { -%>
-pool <%= $pool %> <%= $chrony::pools[$pool].join(' ') %>
-<% } else { -%>
+<% $pools.keys.sort.each |$pool| { -%>
+<%   if $pools[$pool].empty { -%>
 pool <%= $pool %>
+<%   } else { -%>
+pool <%= $pool %> <%= $pools[$pool].join(' ') %>
+<%   } -%>
 <% } -%>
-<% } -%>
-<% } else { -%>
-<% $chrony::pools.each |$pool| { -%>
-pool <%= $pool %> iburst
-<% } -%>
-<% } -%>
-<% if $chrony::peers.is_a(Hash) { -%>
-<%   $chrony::peers.keys.sort.each |$peer| { -%>
-<%     if $chrony::peers[$peer] and !$chrony::peers[$peer].empty { -%>
-peer <%= $peer %> <%= $chrony::peers[$peer].join(' ') %>
-<% } else { -%>
+<% $peers.keys.sort.each |$peer| { -%>
+<%   if $peers[$peer].empty { -%>
 peer <%= $peer %>
-<% } -%>
-<% } -%>
-<% } else { -%>
-<% $chrony::peers.each |$peer| { -%>
-peer <%= $peer %>
-<% } -%>
+<%   } else { -%>
+peer <%= $peer %> <%= $peers[$peer].join(' ') %>
+<%   } -%>
 <% } -%>
 <% if $chrony::stratumweight { -%>
 

--- a/types/servers.pp
+++ b/types/servers.pp
@@ -1,3 +1,25 @@
+# @summary Type for the `servers`, `pools` and `peers` parameters.
+#
+# This type is for the `servers`, `pools` and `peers` parameters.
+#
+# @example A hash of servers
+#   {
+#     'ntp1.example.com => [
+#       'minpoll 3',
+#       'maxpoll 6',
+#     ],
+#     'ntp2.example.com => [
+#       'iburst',
+#       'minpoll 4',
+#       'maxpoll 8',
+#     ],
+#   }
+#
+# @example An array of servers
+#   [
+#     'ntp1.example.com',
+#     'ntp2.example.com',
+#   ]
 type Chrony::Servers = Variant[
   Hash[Stdlib::Host, Optional[Array[String]]],
   Array[Stdlib::Host],

--- a/types/servers.pp
+++ b/types/servers.pp
@@ -1,0 +1,4 @@
+type Chrony::Servers = Variant[
+  Hash[Stdlib::Host, Optional[Array[String]]],
+  Array[Stdlib::Host],
+]


### PR DESCRIPTION
Before the conversion to epp in
https://github.com/voxpupuli/puppet-chrony/pull/79, an array of
servers/pools would get the `iburst` option set for each server/pool.

This restores the old behaviour and gets rid of the `flatten` magic at
the expense of several extra lines of template.