### PR TITLE
Add the bindaddress configuration option for chronyd.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -130,6 +130,14 @@ class { 'chrony':
 
 The following parameters are available in the `chrony` class.
 
+##### `bindaddress`
+
+Data type: `Optional[String]`
+
+Address of an interface on which chronyd will listen for NTP traffic.
+
+Default value: ``undef``
+
 ##### `bindcmdaddress`
 
 Data type: `Array[String]`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,7 @@
 #
 # @api private
 class chrony::config (
+  $bindaddress          = $chrony::address,
   $bindcmdaddress       = $chrony::bindcmdaddress,
   $chrony_password      = $chrony::chrony_password,
   $clientlog            = $chrony::clientlog,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@
 #
 # @api private
 class chrony::config (
-  $bindaddress          = $chrony::address,
+  $bindaddress          = $chrony::bindaddress,
   $bindcmdaddress       = $chrony::bindcmdaddress,
   $chrony_password      = $chrony::chrony_password,
   $clientlog            = $chrony::clientlog,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,8 @@
 #
 # @see https://chrony.tuxfamily.org
 #
+# @param bindaddress
+#   Address of an interface on which chronyd will listen for NTP traffic.
 # @param bindcmdaddress
 #   Array of addresses of interfaces on which chronyd will listen for monitoring command packets.
 # @param cmdacl
@@ -187,6 +189,7 @@
 # @param dumpdir
 #   Directory to store measurement history in on exit.
 class chrony (
+  Optional[String] $bindaddress                                    = undef,
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
   Optional[Stdlib::Port] $cmdport                                  = undef,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -144,6 +144,7 @@ describe 'chrony' do
             config_keys_group: 'mrt',
             config_keys_manage: true,
             chrony_password: 'sunny',
+            bindaddress: '10.0.0.1',
             bindcmdaddress: ['10.0.0.1'],
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
@@ -188,6 +189,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
 
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
@@ -212,6 +214,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -144,7 +144,7 @@ describe 'chrony' do
             config_keys_group: 'mrt',
             config_keys_manage: true,
             chrony_password: 'sunny',
-            bindaddress: '10.0.0.1',
+            bindaddress: '127.0.0.1',
             bindcmdaddress: ['10.0.0.1'],
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
@@ -189,7 +189,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
 
-              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress 127\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
@@ -214,7 +214,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
-              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 127\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -59,6 +59,11 @@ bindcmdaddress <%= $addr %>
 <% $chrony::cmdacl.each |$acl| { -%>
 <%= $acl %>
 <% } -%>
+<% if $chrony::bindaddress { -%>
+
+# Bind to a specific address
+bindaddress <%= $chrony::bindaddress %>
+<% } -%>
 <% if $chrony::port { -%>
 
 # http://chrony.tuxfamily.org/manual.html#port-directive


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
New feature. Users may need to restrict on what interface chronyd
listens; adding this configuration option makes that possible.
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
