### PR TITLE
add bindaddress option

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -131,6 +131,14 @@ class { 'chrony':
 
 The following parameters are available in the `chrony` class.
 
+##### `bindaddress`
+
+Data type: `Optional[String]`
+
+Address of an interface on which chronyd will listen for NTP traffic.
+
+Default value: ``undef``
+
 ##### `bindcmdaddress`
 
 Data type: `Array[String]`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,11 +133,12 @@ The following parameters are available in the `chrony` class.
 
 ##### `bindaddress`
 
-Data type: `Optional[Stdlib::IP::Address]`
+Data type: `Array[Stdlib::IP::Address]`
 
-Address of an interface on which chronyd will listen for NTP traffic.
+Array of addresses of interfaces on which chronyd will listen for NTP traffic.
+Listens on all addresses if left empty.
 
-Default value: ``undef``
+Default value: `[]`
 
 ##### `bindcmdaddress`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,7 +133,7 @@ The following parameters are available in the `chrony` class.
 
 ##### `bindaddress`
 
-Data type: `Optional[String]`
+Data type: `Optional[Stdlib::IP::Address]`
 
 Address of an interface on which chronyd will listen for NTP traffic.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,7 @@
 #
 # @api private
 class chrony::config (
+  $bindaddress          = $chrony::bindaddress,
   $bindcmdaddress       = $chrony::bindcmdaddress,
   $chrony_password      = $chrony::chrony_password,
   $clientlog            = $chrony::clientlog,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -190,7 +190,7 @@
 # @param dumpdir
 #   Directory to store measurement history in on exit.
 class chrony (
-  Optional[String] $bindaddress                                    = undef,
+  Optional[Stdlib::IP::Address] $bindaddress                       = undef,
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
   Optional[Stdlib::Port] $cmdport                                  = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,8 @@
 #
 # @see https://chrony.tuxfamily.org
 #
+# @param bindaddress
+#   Address of an interface on which chronyd will listen for NTP traffic.
 # @param bindcmdaddress
 #   Array of addresses of interfaces on which chronyd will listen for monitoring command packets.
 # @param cmdacl
@@ -188,6 +190,7 @@
 # @param dumpdir
 #   Directory to store measurement history in on exit.
 class chrony (
+  Optional[String] $bindaddress                                    = undef,
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
   Optional[Stdlib::Port] $cmdport                                  = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,8 @@
 # @see https://chrony.tuxfamily.org
 #
 # @param bindaddress
-#   Address of an interface on which chronyd will listen for NTP traffic.
+#   Array of addresses of interfaces on which chronyd will listen for NTP traffic.
+#   Listens on all addresses if left empty.
 # @param bindcmdaddress
 #   Array of addresses of interfaces on which chronyd will listen for monitoring command packets.
 # @param cmdacl
@@ -190,7 +191,7 @@
 # @param dumpdir
 #   Directory to store measurement history in on exit.
 class chrony (
-  Optional[Stdlib::IP::Address] $bindaddress                       = undef,
+  Array[Stdlib::IP::Address] $bindaddress                          = [],
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
   Optional[Stdlib::Port] $cmdport                                  = undef,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -144,6 +144,7 @@ describe 'chrony' do
             config_keys_group: 'mrt',
             config_keys_manage: true,
             chrony_password: 'sunny',
+            bindaddress: '10.0.0.1',
             bindcmdaddress: ['10.0.0.1'],
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
@@ -191,6 +192,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
 
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
@@ -216,6 +218,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -144,7 +144,7 @@ describe 'chrony' do
             config_keys_group: 'mrt',
             config_keys_manage: true,
             chrony_password: 'sunny',
-            bindaddress: '10.0.0.1',
+            bindaddress: ['10.0.0.1', '::1'],
             bindcmdaddress: ['10.0.0.1'],
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
@@ -191,8 +191,8 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
-
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress ::1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
@@ -219,6 +219,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress ::1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -59,6 +59,11 @@ bindcmdaddress <%= $addr %>
 <% $chrony::cmdacl.each |$acl| { -%>
 <%= $acl %>
 <% } -%>
+<% if $chrony::bindaddress { -%>
+
+# Bind to a specific address
+bindaddress <%= $chrony::bindaddress %>
+<% } -%>
 <% if $chrony::port { -%>
 
 # http://chrony.tuxfamily.org/manual.html#port-directive

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -59,10 +59,12 @@ bindcmdaddress <%= $addr %>
 <% $chrony::cmdacl.each |$acl| { -%>
 <%= $acl %>
 <% } -%>
-<% if $chrony::bindaddress { -%>
+<% unless $chrony::bindaddress.empty { -%>
 
 # Bind to a specific address
-bindaddress <%= $chrony::bindaddress %>
+<%  $chrony::bindaddress.each |$addr| { -%>
+bindaddress <%= $addr %>
+<%   } -%>
 <% } -%>
 <% if $chrony::port { -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description
Add the `bindaddress` configuration option to chrony.conf.

This will allow users to specify an IP address on an interface on which chronyd should listen.

#### This Pull Request (PR) fixes the following issues
n/a