### PR TITLE
Allow users to not set local stratum

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,7 +202,7 @@ class chrony (
   Boolean $config_keys_manage                                      = true,
   Array[String[1]] $keys                                           = [],
   Stdlib::Unixpath $driftfile                                      = '/var/lib/chrony/drift',
-  Integer[1,15] $local_stratum                                     = 10,
+  Variant[Boolean[false],Integer[1,15]] $local_stratum             = 10,
   Optional[String[1]] $log_options                                 = undef,
   String[1] $package_ensure                                        = 'present',
   String[1] $package_name                                          = $chrony::params::package_name,


### PR DESCRIPTION
#### Pull Request (PR) description
The template uses a conditional statement but it always evaluates to true
and a result users can't disable the usage of local stratum.

We can fix that by adjusting the data type of the local_stratum
parameter to accept the Boolean false value. So, users can set it to
`false` and the template doesn't render the specific block as the
conditional statement evaluates to false.

#### This Pull Request (PR) fixes the following issues
No issue was opened for this.
