### PR TITLE
Allow users to not set local stratum

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,8 @@
 #   A file for chrony to record clock drift in.
 # @param local_stratum
 #   Override the stratum of the server which will be reported to clients
-#   when the local reference is active.
+#   when the local reference is active. Use `false` to not set local_stratum in
+#   chrony configuration.
 # @param stratumweight
 #   Sets how much distance should be added per stratum to the synchronisation distance when chronyd
 #   selects the synchronisation source from available sources.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,7 +202,7 @@ class chrony (
   Boolean $config_keys_manage                                      = true,
   Array[String[1]] $keys                                           = [],
   Stdlib::Unixpath $driftfile                                      = '/var/lib/chrony/drift',
-  Integer[1,15] $local_stratum                                     = 10,
+  Variant[Boolean[false],Integer[1,15]] $local_stratum             = 10,
   Optional[String[1]] $log_options                                 = undef,
   String[1] $package_ensure                                        = 'present',
   String[1] $package_name                                          = $chrony::params::package_name,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -484,6 +484,22 @@ describe 'chrony' do
           end
         end
       end
+
+      context 'disable local_stratum' do
+        let(:params) do
+          {
+            local_stratum: false
+          }
+        end
+
+        case facts[:os]['family']
+        when 'Archlinux', 'Redhat'
+          it { is_expected.not_to contain_file('/etc/chrony.conf').with_content(%r{^\s*local stratum}) }
+        when 'Debian', 'Gentoo'
+          it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*local stratum}) }
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
The template uses a conditional statement but it always evaluates to true
and a result users can't disable the usage of local stratum.

We can fix that by adjusting the data type of the local_stratum
parameter to accept the Boolean false value. So, users can set it to
`false` and the template doesn't render the specific block as the
conditional statement evaluates to false.

#### This Pull Request (PR) fixes the following issues
No issue was opened for this.
