### PR TITLE
Fix CI on CentOS

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,5 @@
+if fact('os.family') == 'redhat' {
+  file { '/var/run/chrony':
+    ensure => directory,
+  }
+}


### PR DESCRIPTION
#### Pull Request (PR) description

We are experiencing CI failures on CentOS because the service cannot start because it cannot create it's PID file.

Running the very same test locally works as expected, so the root cause of the different behavior on the CI is unfortunately unknown.  Yet, ensuring the directory for the PID file exist seems to fix the CI issue.

#### This Pull Request (PR) fixes the following issues

n/a