### PR TITLE
Add initstepslew

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -267,6 +267,15 @@ A file for chrony to record clock drift in.
 
 Default value: `'/var/lib/chrony/drift'`
 
+##### `initstepslew`
+
+Data type: `Optional[String]`
+
+Allow chronyd to make a rapid measurement of the system clock error at boot time,
+and to correct the system clock by stepping before normal operation begins.
+
+Default value: ``undef``
+
 ##### `local_stratum`
 
 Data type: `Integer[1,15]`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,6 +19,7 @@ class chrony::config (
   $config_keys_template = $chrony::config_keys_template,
   $config_template      = $chrony::config_template,
   $keys                 = $chrony::keys,
+  $initstepslew         = $chrony::initstepslew,
   $leapsecmode          = $chrony::leapsecmode,
   $leapsectz            = $chrony::leapsectz,
   $local_stratum        = $chrony::local_stratum,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,9 @@
 #   Listens on all addresses if left empty.
 # @param bindcmdaddress
 #   Array of addresses of interfaces on which chronyd will listen for monitoring command packets.
+# @param initstepslew
+#   Allow chronyd to make a rapid measurement of the system clock error at boot time,
+#   and to correct the system clock by stepping before normal operation begins.
 # @param cmdacl
 #   An array of ACLs for monitoring access. This expects a list of directives, for
 #   example: `['cmdallow 1.2.3.4', 'cmddeny 1.2.3']`. The order will be respected at
@@ -193,6 +196,7 @@
 class chrony (
   Array[Stdlib::IP::Address] $bindaddress                          = [],
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
+  Optional[String] $initstepslew                                   = undef,
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
   Optional[Stdlib::Port] $cmdport                                  = undef,
   $commandkey                                                      = 0,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -220,12 +220,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
-<<<<<<< HEAD
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress ::1$}) }
-=======
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*initstepslew 600$}) }
->>>>>>> Add initstepslew parameter which allows chronyd to make a rapid measurement of the system clock error at boot time, and to correct the system clock by stepping before normal operation begins
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -146,6 +146,7 @@ describe 'chrony' do
             chrony_password: 'sunny',
             bindaddress: ['10.0.0.1', '::1'],
             bindcmdaddress: ['10.0.0.1'],
+            initstepslew: '600'
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
             leapsectz: 'right/UTC',
@@ -193,6 +194,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress ::1$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*initstepslew 600$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
@@ -218,8 +220,12 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
+<<<<<<< HEAD
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress ::1$}) }
+=======
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*initstepslew 600$}) }
+>>>>>>> Add initstepslew parameter which allows chronyd to make a rapid measurement of the system clock error at boot time, and to correct the system clock by stepping before normal operation begins
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -146,7 +146,7 @@ describe 'chrony' do
             chrony_password: 'sunny',
             bindaddress: ['10.0.0.1', '::1'],
             bindcmdaddress: ['10.0.0.1'],
-            initstepslew: '600'
+            initstepslew: '600',
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
             leapsectz: 'right/UTC',

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -65,6 +65,7 @@ bindcmdaddress <%= $addr %>
 <%  $chrony::bindaddress.each |$addr| { -%>
 bindaddress <%= $addr %>
 <%   } -%>
+<% } -%>
 <% if $chrony::initstepslew { -%>
 
 # Allow chronyd to make a rapid measurement of the system clock error at boot time,

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -65,6 +65,11 @@ bindcmdaddress <%= $addr %>
 <%  $chrony::bindaddress.each |$addr| { -%>
 bindaddress <%= $addr %>
 <%   } -%>
+<% if $chrony::initstepslew { -%>
+
+# Allow chronyd to make a rapid measurement of the system clock error at boot time,
+# and to correct the system clock by stepping before normal operation begins.
+initstepslew <%= $chrony::initstepslew %>
 <% } -%>
 <% if $chrony::port { -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description
Add initstepslew parameter which allows chronyd to make a rapid measurement of the system clock error at boot time, and to correct the system clock by stepping before normal operation begins

#### This Pull Request (PR) fixes the following issues
Adds new functionality to the module that wasn't available
