### PR TITLE
Add support for maxdistance

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,8 @@
 #   Configures how to insert the leap second mode.
 # @param leapsectz
 #   Specifies a timezone that chronyd can use to determine the offset between UTC and TAI.
+# @param maxdistance
+#   Sets the maximum root distance of a source to be acceptable for synchronisation of the clock.
 # @param maxslewrate
 #   Maximum rate for chronyd to slew the time. Only float type values possible, for example: `maxslewrate 1000.0`.
 # @param clientlog
@@ -242,6 +244,7 @@ class chrony (
   Optional[String] $smoothtime                                     = undef,
   Optional[Enum['system', 'step', 'slew', 'ignore']] $leapsecmode  = undef,
   Optional[String] $leapsectz                                      = undef,
+  Optional[Float] $maxdistance                                     = undef,
   Optional[Float] $maxslewrate                                     = undef,
   Optional[Float] $maxupdateskew                                   = undef,
   Optional[Numeric] $stratumweight                                 = undef,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -150,6 +150,7 @@ describe 'chrony' do
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
             leapsectz: 'right/UTC',
+            maxdistance: 16.0,
             maxslewrate: 1000.0,
             maxupdateskew: 1000.0,
             smoothtime: '400 0.001 leaponly',
@@ -180,12 +181,14 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_replace(true) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_content(sensitive("0 sunny\n")) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*maxdistance 16\.0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*maxupdateskew 1000\.0$}) }
             end
           when 'RedHat'
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*leapsecmode slew$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*leapsectz right/UTC$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*maxdistance 16\.0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*maxslewrate 1000\.0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*maxupdateskew 1000\.0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }
@@ -214,6 +217,7 @@ describe 'chrony' do
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*leapsectz right/UTC$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*leapsecmode slew$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*maxdistance 16\.0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*maxslewrate 1000\.0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*maxupdateskew 1000\.0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -138,6 +138,11 @@ leapsecmode <%= $chrony::leapsecmode %>
 # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#leapsectz
 leapsectz <%= $chrony::leapsectz %>
 <% } -%>
+<% if $chrony::maxdistance { -%>
+
+# https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#maxdistance
+maxdistance <%= $chrony::maxdistance %>
+<% } -%>
 <% if $chrony::maxupdateskew { -%>
 
 # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#maxupdateskew


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds support for the `maxdistance` config option which [`sets the maximum root distance of a source to be acceptable for synchronisation of the clock`](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#maxdistance) and may be [required in certain setups (some Windows NTP Servers)](https://chrony.tuxfamily.org/faq.html#_using_a_windows_ntp_server).

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
I did not find an existing issue for this feature and did not open one as the PR is low-effort and seems straight-forward.
