### PR TITLE
Manage chrony-wait.service on RedHat and Suse

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ class { 'chrony':
 }
 ```
 
+### Enable chrony-wait.service
+RedHat and Suse provide a default disabled `chrony-wait.service` to block the `time-sync.target`
+until node is synchronised.
+
+To enable it:
+
+```puppet
+class{ 'chrony':
+  wait_enable => true,
+  wait_ensure => true,
+}
+```
+
 ## Reference
 
 Reference documentation for the chrony module is generated using

--- a/README.md
+++ b/README.md
@@ -87,10 +87,8 @@ class { 'chrony':
 
 ```puppet
 class { 'chrony':
-  keys            => [
-    '25 SHA1 HEX:1dc764e0791b11fa67efc7ecbc4b0d73f68a070c',
-  ],
-  servers         => {
+  keys    => ['25 SHA1 HEX:1dc764e0791b11fa67efc7ecbc4b0d73f68a070c'],
+  servers => {
     'ntp1.corp.com' => ['key 25', 'iburst'],
     'ntp2.corp.com' => ['key 25', 'iburst'],
   },
@@ -131,7 +129,7 @@ until node is synchronised.
 To enable it:
 
 ```puppet
-class{ 'chrony':
+class { 'chrony':
   wait_enable => true,
   wait_ensure => true,
 }

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -166,12 +166,17 @@ The following parameters are available in the `chrony` class:
 * [`service_ensure`](#service_ensure)
 * [`service_manage`](#service_manage)
 * [`service_name`](#service_name)
+* [`wait_enable`](#wait_enable)
+* [`wait_ensure`](#wait_ensure)
+* [`wait_manage`](#wait_manage)
+* [`wait_name`](#wait_name)
 * [`smoothtime`](#smoothtime)
 * [`mailonchange`](#mailonchange)
 * [`threshold`](#threshold)
 * [`lock_all`](#lock_all)
 * [`leapsecmode`](#leapsecmode)
 * [`leapsectz`](#leapsectz)
+* [`maxdistance`](#maxdistance)
 * [`maxslewrate`](#maxslewrate)
 * [`clientlog`](#clientlog)
 * [`clientloglimit`](#clientloglimit)
@@ -512,6 +517,38 @@ This selects the name of the chrony service for puppet to manage.
 
 Default value: `$chrony::params::service_name`
 
+##### <a name="wait_enable"></a>`wait_enable`
+
+Data type: `Boolean`
+
+This determines if the chrony-wait service should be enabled at boot.
+
+Default value: ``false``
+
+##### <a name="wait_ensure"></a>`wait_ensure`
+
+Data type: `Stdlib::Ensure::Service`
+
+This determines if the chrony-wait service should be running or not.
+
+Default value: `'stopped'`
+
+##### <a name="wait_manage"></a>`wait_manage`
+
+Data type: `Boolean`
+
+This selects if puppet should manage the chrony-wait service in the first place.
+
+Default value: `$chrony::params::wait_manage`
+
+##### <a name="wait_name"></a>`wait_name`
+
+Data type: `String[1]`
+
+This selects the name of the chrony-wait service for puppet to manage.
+
+Default value: `'chrony-wait.service'`
+
 ##### <a name="smoothtime"></a>`smoothtime`
 
 Data type: `Optional[String]`
@@ -557,6 +594,14 @@ Default value: ``undef``
 Data type: `Optional[String]`
 
 Specifies a timezone that chronyd can use to determine the offset between UTC and TAI.
+
+Default value: ``undef``
+
+##### <a name="maxdistance"></a>`maxdistance`
+
+Data type: `Optional[Float]`
+
+Sets the maximum root distance of a source to be acceptable for synchronisation of the clock.
 
 Default value: ``undef``
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,14 @@
 #   This selects if puppet should manage the service in the first place.
 # @param service_name
 #   This selects the name of the chrony service for puppet to manage.
+# @param wait_enable
+#   This determines if the chrony-wait service should be enabled at boot.
+# @param wait_ensure
+#   This determines if the chrony-wait service should be running or not.
+# @param wait_manage
+#   This selects if puppet should manage the chrony-wait service in the first place.
+# @param wait_name
+#   This selects the name of the chrony-wait service for puppet to manage.
 # @param smoothtime
 #   Specify the smoothing of the time parameter as a string, for example `smoothtime 50000 0.01`.
 # @param mailonchange
@@ -241,6 +249,10 @@ class chrony (
   Stdlib::Ensure::Service $service_ensure                          = 'running',
   Boolean $service_manage                                          = true,
   String[1] $service_name                                          = $chrony::params::service_name,
+  Boolean $wait_enable                                             = false,
+  Stdlib::Ensure::Service $wait_ensure                             = 'stopped',
+  Boolean $wait_manage                                             = $chrony::params::wait_manage,
+  String[1] $wait_name                                             = 'chrony-wait.service',
   Optional[String] $smoothtime                                     = undef,
   Optional[Enum['system', 'step', 'slew', 'ignore']] $leapsecmode  = undef,
   Optional[String] $leapsectz                                      = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class chrony::params {
       $config_keys_group = 0
       $config_keys_mode  = '0644'
       $service_name      = 'chronyd'
+      $wait_manage       = false
       $clientlog         = true
       $rtconutc          = true
       $dumpdir           = '/var/lib/chrony'
@@ -25,6 +26,7 @@ class chrony::params {
       $config_keys_group = 0
       $config_keys_mode  = '0644'
       $service_name      = 'chronyd'
+      $wait_manage       = false
       $clientlog         = true
       $rtconutc          = true
       $dumpdir           = undef
@@ -38,6 +40,7 @@ class chrony::params {
       $config_keys_group = chrony
       $config_keys_mode  = '0640'
       $service_name      = 'chronyd'
+      $wait_manage       = true
       $clientlog         = false
       $rtconutc          = false
       $dumpdir           = undef
@@ -51,6 +54,7 @@ class chrony::params {
       $config_keys_group = 0
       $config_keys_mode  = '0640'
       $service_name      = 'chrony'
+      $wait_manage       = false
       $clientlog         = false
       $rtconutc          = false
       $dumpdir           = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,4 +10,11 @@ class chrony::service {
       enable => $chrony::service_enable,
     }
   }
+
+  if $chrony::wait_manage {
+    service { $chrony::wait_name:
+      ensure => $chrony::wait_ensure,
+      enable => $chrony::wait_enable,
+    }
+  }
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -20,10 +20,54 @@ describe 'chrony class:' do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
+    describe service('chrony-wait.service') do
+      it { is_expected.not_to be_enabled }
+      it { is_expected.not_to be_running }
+    end
   else
     describe service('chrony') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
+    end
+    describe service('chrony-wait.service') do
+      it { is_expected.not_to be_running }
+      it { is_expected.not_to be_running }
+    end
+
+  end
+
+  describe 'with chrony-wait service enabled' do
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class { 'chrony':
+        wait_ensure => 'running',
+        wait_enable => true,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    if fact('os.family') == 'RedHat'
+      describe service('chronyd') do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+      describe service('chrony-wait.service') do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+    else
+      describe service('chrony') do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+      describe service('chrony-wait.service') do
+        it { is_expected.not_to be_running }
+        it { is_expected.not_to be_running }
+      end
     end
   end
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -15,14 +15,13 @@ describe 'chrony class:' do
     it { is_expected.to be_installed }
   end
 
-  if os[:family] == 'RedHat'
-    describe service(chronyd) do
+  if fact('os.family') == 'RedHat'
+    describe service('chronyd') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
-  end
-  if os[:family] == 'Debian'
-    describe service(chrony) do
+  else
+    describe service('chrony') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -470,6 +470,24 @@ describe 'chrony' do
         end
 
         case facts[:os]['family']
+        when 'RedHat', 'Suse'
+          context 'using defaults' do
+            it do
+              is_expected.to contain_service('chrony-wait.service').with(
+                ensure: 'stopped',
+                enable: false
+              )
+            end
+          end
+        else
+          context 'using defaults' do
+            it do
+              is_expected.not_to contain_service('chrony-wait.service')
+            end
+          end
+        end
+
+        case facts[:os]['family']
         when 'Archlinux'
           context 'using defaults' do
             it do
@@ -496,6 +514,56 @@ describe 'chrony' do
                 enable: true
               )
             end
+          end
+        end
+      end
+
+      context 'with wait_manage false' do
+        let(:params) do
+          { wait_manage: false }
+        end
+
+        it do
+          is_expected.not_to contain_service('chrony-wait.service')
+        end
+      end
+
+      context 'with wait_enable true' do
+        let(:params) do
+          { wait_enable: true }
+        end
+
+        case facts[:os]['family']
+        when 'RedHat', 'Suse'
+          it do
+            is_expected.to contain_service('chrony-wait.service').with(
+              ensure: 'stopped',
+              enable: true
+            )
+          end
+        else
+          it do
+            is_expected.not_to contain_service('chrony-wait.service')
+          end
+        end
+      end
+
+      context 'with wait_ensure running' do
+        let(:params) do
+          { wait_ensure: 'running' }
+        end
+
+        case facts[:os]['family']
+        when 'RedHat', 'Suse'
+          it do
+            is_expected.to contain_service('chrony-wait.service').with(
+              ensure: 'running',
+              enable: false
+            )
+          end
+        else
+          it do
+            is_expected.not_to contain_service('chrony-wait.service')
           end
         end
       end

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -514,7 +514,6 @@ describe 'chrony' do
           it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*local stratum}) }
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

On Redhat and Suse the service `chrony-wait.service` can be enabled and
or started to force the `time-sync.target` to really wait for
synchronisation to occur before proceeding on to other services
that are after `time-sync.target`.

```puppet
class{'chrony':
  wait_enable => 'running',
  wait_ensure => true,
}