### PR TITLE
Update github URLs to remove unauthenticated git

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "author": "Vox Pupuli",
   "summary": "Manage chrony daemon on Linux",
   "license": "Apache-2.0",
-  "source": "git://github.com/voxpupuli/puppet-chrony.git",
+  "source": "https://github.com/voxpupuli/puppet-chrony.git",
   "project_page": "https://github.com/voxpupuli/puppet-chrony",
   "issues_url": "https://github.com/voxpupuli/puppet-chrony/issues",
   "dependencies": [


### PR DESCRIPTION
#### Pull Request (PR) description
Per [github](https://github.blog/2021-09-01-improving-git-protocol-security-github/), "unencrypted git:// offers no integrity or authentication, [...] We’ll be disabling support for this protocol."

This switches the protocols to https:// which they indicate is unaffected.