### PR TITLE
Add `sched_priority` and `logbanner` options.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,6 +111,8 @@
 #   When not set, chronyd's default will be used, which since version 2.0 of chrony, is 0.001 seconds.
 # @param log_options
 #   Specify which information is to be logged.
+# @param logbanner
+#   Specify how often the log banner is placed in the logfile.
 # @param package_ensure
 #   This can be set to 'present' or 'latest' or a specific version to choose the
 #   chrony package to be installed.
@@ -184,6 +186,8 @@
 #   Specify the time limit for triggering events.
 # @param lock_all
 #   Force chrony to only use RAM & prevent swapping.
+# @param sched_priority
+#   Set the CPU thread scheduler, this value is OS specific.
 # @param leapsecmode
 #   Configures how to insert the leap second mode.
 # @param leapsectz
@@ -251,6 +255,7 @@ class chrony (
   Stdlib::Unixpath $driftfile                                      = '/var/lib/chrony/drift',
   Variant[Boolean[false],Integer[1,15]] $local_stratum             = 10,
   Optional[String[1]] $log_options                                 = undef,
+  Optional[Integer[0]] $logbanner                                  = undef,
   String[1] $package_ensure                                        = 'present',
   String[1] $package_name                                          = 'chrony',
   Optional[String] $package_source                                 = undef,
@@ -270,6 +275,7 @@ class chrony (
   Optional[String[1]] $mailonchange                                = undef,
   Float $threshold                                                 = 0.5,
   Boolean $lock_all                                                = false,
+  Optional[Integer[0,100]] $sched_priority                         = undef,
   Optional[Stdlib::Port] $port                                     = undef,
   Boolean $clientlog                                               = false,
   Optional[Integer] $clientloglimit                                = undef,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -152,6 +152,8 @@ describe 'chrony' do
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
             leapsectz: 'right/UTC',
+            log_options: 'statistics refclocks',
+            logbanner: 40,
             maxdistance: 16.0,
             maxslewrate: 1000.0,
             maxupdateskew: 1000.0,
@@ -160,6 +162,7 @@ describe 'chrony' do
             hwtimestamps: ['eth0'],
             driftfile: '/var/tmp/chrony.drift',
             rtcsync: false,
+            sched_priority: 1,
             dumpdir: '/var/tmp',
             ntpsigndsocket: '/var/lib/samba/ntp_signd/socket',
             ntsserverkey: '/tmp/cert.key',
@@ -205,6 +208,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*ntsrotate 8$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*confdir /tmp/chroconf$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sourcedir /tmp/chrosources$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*log statistics refclocks$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*logbanner 40$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sched_priority 1$}) }
             end
           when 'RedHat'
             context 'with some params passed in' do
@@ -245,6 +251,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*ntsrotate 8$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*confdir /tmp/chroconf$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sourcedir /tmp/chrosources$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*log statistics refclocks$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*logbanner 40$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sched_priority 1$}) }
             end
           when 'Debian', 'Gentoo'
             context 'with some params passed in' do
@@ -285,6 +294,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*ntsrotate 8$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*confdir /tmp/chroconf$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*sourcedir /tmp/chrosources$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*log statistics refclocks$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*logbanner 40$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*sched_priority 1$}) }
             end
           end
         end

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -127,6 +127,9 @@ mailonchange <%= $chrony::mailonchange %> <%= $chrony::threshold %>
 <% } -%>
 
 logdir /var/log/chrony
+<% if $chrony::logbanner { -%>
+logbanner <%= $chrony::logbanner %>
+<% } -%>
 <% if $chrony::log_options { -%>
 log <%= $chrony::log_options %>
 <% } -%>
@@ -140,6 +143,9 @@ refclock <%= $driver.flatten.join(' ') %>
 
 # Lock chrony to RAM.
 lock_all
+<% } -%>
+<% if $chrony::sched_priority { -%>
+sched_priority <%= $chrony::sched_priority %>
 <% } -%>
 <% if $chrony::leapsecmode { -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description
This patch adds a way to set the chrony options `sched_priority` and `logbanner`.

#### This Pull Request (PR) fixes the following issues
None
