### PR TITLE
Add more config settings and prep EL9 support

### DIFF
--- a/data/RedHat/9.yaml
+++ b/data/RedHat/9.yaml
@@ -1,0 +1,4 @@
+---
+chrony::leapsectz: right/UTC
+chrony::ntsdumpdir: /var/lib/chrony
+chrony::makestep_seconds: 1.0

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -4,4 +4,5 @@ version: 5
 hierarchy:
   - name: OS family
     paths:
+      - '%{facts.os.family}/%{facts.os.release.major}.yaml'
       - '%{facts.os.family}.yaml'

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -136,6 +136,7 @@ describe 'chrony' do
         let(:params) do
           {
             queryhosts: ['192.168/16'],
+            denyqueryhosts: ['10.0/16'],
             port: 123,
             cmdport: 257,
             config_keys_mode: '0123',
@@ -153,6 +154,7 @@ describe 'chrony' do
             leapsectz: 'right/UTC',
             log_options: 'statistics refclocks',
             logbanner: 40,
+            logchange: 4.0,
             maxdistance: 16.0,
             maxslewrate: 1000.0,
             maxupdateskew: 1000.0,
@@ -168,6 +170,9 @@ describe 'chrony' do
             ntsservercert: '/tmp/cert.pem',
             ntsport: 12,
             maxntsconnections: 32,
+            minsources: 22,
+            minsamples: 33,
+            acquisitionport: 321,
             ntsprocesses: 5,
             ntsdumpdir: '/tmp/ntsdump',
             ntsntpserver: 'foo.bar',
@@ -181,10 +186,12 @@ describe 'chrony' do
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168/16$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*deny 10\.0/16$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*rtconutc$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*acquisitionport 321$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*hwtimestamp eth0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*driftfile /var/tmp/chrony.drift$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').without_content(%r{^\s*rtcsync$}) }
@@ -209,6 +216,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sourcedir /tmp/chrosources$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*log statistics refclocks$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*logbanner 40$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*logchange 4\.0$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*minsources 22$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*minsamples 33$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sched_priority 1$}) }
             end
           when 'RedHat'
@@ -221,7 +231,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*acquisitionport 321$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168/16$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*deny 10\.0/16$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindaddress ::1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*initstepslew 600$}) }
@@ -252,7 +264,10 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sourcedir /tmp/chrosources$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*log statistics refclocks$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*logbanner 40$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*logchange 4\.0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*sched_priority 1$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*minsources 22$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*minsamples 33$}) }
             end
           when 'Debian', 'Gentoo'
             context 'with some params passed in' do
@@ -264,7 +279,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*acquisitionport 321$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168/16$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*deny 10\.0/16$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindaddress ::1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*initstepslew 600$}) }
@@ -295,7 +312,10 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*sourcedir /tmp/chrosources$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*log statistics refclocks$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*logbanner 40$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*logchange 4\.0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*sched_priority 1$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*minsources 22$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*minsamples 33$}) }
             end
           end
         end

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -52,6 +52,13 @@ rtcsync
 # if the adjustment is larger than <%= $chrony::makestep_seconds %> seconds.
 makestep <%= $chrony::makestep_seconds %> <%= $chrony::makestep_updates %>
 <% } -%>
+<% unless $chrony::denyqueryhosts.empty { -%>
+
+# Deny client access.
+<%   $chrony::denyqueryhosts.each |$denied| { -%>
+deny <%= $denied %>
+<%   } -%>
+<% } -%>
 <% unless $chrony::queryhosts.empty { -%>
 
 # Allow client access.
@@ -78,6 +85,9 @@ bindcmdaddress <%= $addr %>
 bindaddress <%= $addr %>
 <%   } -%>
 <% } -%>
+<% unless $chrony::acquisitionport.empty { -%>
+acquisitionport <%= $chrony::acquisitionport %>
+<% } -%>
 <% if $chrony::initstepslew { -%>
 
 # Allow chronyd to make a rapid measurement of the system clock error at boot time,
@@ -93,6 +103,16 @@ port <%= $chrony::port %>
 
 # Serve time even if not synchronized to any NTP server.
 local stratum <%= $chrony::local_stratum %>
+<% } -%>
+<% if $chrony::minsamples { -%>
+
+# https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#minsamples
+minsamples <%= $chrony::minsamples %>
+<% } -%>
+<% if $chrony::minsources { -%>
+
+# https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#minsources
+minsources <%= $chrony::minsources %>
 <% } -%>
 <% if $chrony::config_keys { -%>
 
@@ -120,11 +140,11 @@ noclientlog
 clientloglimit <%= $chrony::clientloglimit %>
 <% } -%>
 
-# Send a message to syslog if a clock adjustment is larger than 0.5 seconds.
-logchange 0.5
+# Send a message to syslog if a clock adjustment is larger than the specified threshold
+logchange <%= $chrony::logchange %>
 <% if $chrony::mailonchange { -%>
 
-# Send mail  if chronyd applied a correction exceeding given threshold.
+# Send mail if chronyd applied a correction exceeding given threshold.
 mailonchange <%= $chrony::mailonchange %> <%= $chrony::threshold %>
 <% } -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description
Add new defaults for EL9 and a way to explicitly deny query hosts.  Some data constraints and logging options are featured as well.

#### This Pull Request (PR) fixes the following issues
Replaces: https://github.com/voxpupuli/puppet-chrony/pull/138
Replaces: https://github.com/voxpupuli/puppet-chrony/pull/124
