### PR TITLE
make config_keys option optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -302,9 +302,9 @@ Default value: `'chrony/chrony.conf.epp'`
 
 ##### <a name="config_keys"></a>`config_keys`
 
-Data type: `Stdlib::Unixpath`
+Data type: `Variant[Stdlib::Unixpath,String[0,0]]`
 
-This sets the file to write chrony keys into.
+This sets the file to write chrony keys into. Set to '' to remove `keyfile` attribute from the config.
 
 Default value: `'/etc/chrony/chrony.keys'`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,12 +31,14 @@ class chrony::config {
     'keys' => $chrony::keys,
   }
 
-  file { $chrony::config_keys:
-    ensure  => file,
-    replace => $chrony::config_keys_manage,
-    owner   => $chrony::config_keys_owner,
-    group   => $chrony::config_keys_group,
-    mode    => $chrony::config_keys_mode,
-    content => Sensitive(epp($chrony::config_keys_template, $keys_params)),
+  unless empty($chrony::config_keys) {
+    file { $chrony::config_keys:
+      ensure  => file,
+      replace => $chrony::config_keys_manage,
+      owner   => $chrony::config_keys_owner,
+      group   => $chrony::config_keys_group,
+      mode    => $chrony::config_keys_mode,
+      content => Sensitive(epp($chrony::config_keys_template, $keys_params)),
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@
 # @param config_template
 #   This determines which template puppet should use for the chrony configuration.
 # @param config_keys
-#   This sets the file to write chrony keys into.
+#   This sets the file to write chrony keys into. Set to '' to remove `keyfile` attribute from the config.
 # @param config_keys_manage
 #   Determines whether puppet will manage the content of the keys file after it has been created for the first time.
 # @param config_keys_template
@@ -258,7 +258,7 @@ class chrony (
   Optional[Stdlib::Absolutepath] $confdir                          = undef,
   Optional[Stdlib::Absolutepath] $sourcedir                        = undef,
   String[1] $config_template                                       = 'chrony/chrony.conf.epp',
-  Stdlib::Unixpath $config_keys                                    = '/etc/chrony/chrony.keys',
+  Variant[Stdlib::Unixpath,String[0,0]] $config_keys               = '/etc/chrony/chrony.keys',
   String[1] $config_keys_template                                  = 'chrony/chrony.keys.epp',
   Variant[Sensitive[String[1]], String[1]] $chrony_password        = 'xyzzy',
   Variant[Integer[0],String[1]] $config_keys_owner                 = 0,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -130,6 +130,19 @@ describe 'chrony' do
             it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_content(sensitive("0 xyzzy\n")) }
           end
         end
+        it { is_expected.to contain_file(config_file).with_content(%r{keyfile .*chrony.keys}) }
+      end
+
+      context 'with empty config_keys' do
+        let :params do
+          {
+            config_keys: ''
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file(config_file).without_content(%r{keyfile .*chrony.keys}) }
+        it { is_expected.not_to contain_file(keys_file) }
       end
 
       context 'with some params passed in' do

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -114,7 +114,7 @@ minsamples <%= $chrony::minsamples %>
 # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#minsources
 minsources <%= $chrony::minsources %>
 <% } -%>
-<% if $chrony::config_keys { -%>
+<% unless empty($chrony::config_keys) { -%>
 
 keyfile <%= $chrony::config_keys %>
 <% } -%>


### PR DESCRIPTION
Previously we always wrote `keyfile` to the chrony configuration file.
This is not always desired. To not cause a breaking change but still
make this configureable, the parameter is now a variant. Besides passing
an absolute path, you can now set it to `''` (empty string). If that's
the case, the keys file won't be managed by Puppet and the option will
be removed from the config file.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
