### PR TITLE
allow logchange to be a float with an arbitrary range

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,7 +268,7 @@ class chrony (
   Array[String[1]] $keys                                           = [],
   Stdlib::Unixpath $driftfile                                      = '/var/lib/chrony/drift',
   Variant[Boolean[false],Integer[1,15]] $local_stratum             = 10,
-  Float[0.1] $logchange                                            = 0.5,
+  Float $logchange                                                 = 0.5,
   Optional[String[1]] $log_options                                 = undef,
   Optional[Integer[0]] $logbanner                                  = undef,
   String[1] $package_ensure                                        = 'present',

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -651,6 +651,16 @@ describe 'chrony' do
           it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*local stratum}) }
         end
       end
+
+      context 'with sub-millisecond value for logchange' do
+        let(:params) do
+          {
+            logchange: 0.0001
+          }
+        end
+
+        it { expect(config_file_contents.split("\n")).to include('logchange 0.0001') }
+      end
     end
   end
 end


### PR DESCRIPTION
The chrony source does not appear to have any restrictions on the range of the logchange value.

See: https://git.tuxfamily.org/chrony/chrony.git/tree/reference.c#n498