### PR TITLE
chrony_spec: fix regexes in "empty allow/deny"

### DIFF
--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -405,8 +405,8 @@ describe 'chrony' do
           }
         end
 
-        it { is_expected.to contain_file(config_file).with_content(%r{^\s*allow\s*}) }
-        it { is_expected.to contain_file(config_file).with_content(%r{^\s*deny\s*}) }
+        it { is_expected.to contain_file(config_file).with_content(%r{^\s*allow\s*$}) }
+        it { is_expected.to contain_file(config_file).with_content(%r{^\s*deny\s*$}) }
       end
 
       context 'unmanaged chrony.keys file' do


### PR DESCRIPTION
Need to anchor the end of line for these tests to be totally correct. Fixes #163.