### PR TITLE
Add Debian hiera data to match package defaults

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,6 @@
+---
+chrony::driftfile: /var/lib/chrony/chrony.drift
+chrony::leapsectz: right/UTC
+chrony::makestep_seconds: 1
+chrony::maxupdateskew: 100.0
+chrony::ntsdumpdir: /var/lib/chrony

--- a/data/Debian/20.04.yaml
+++ b/data/Debian/20.04.yaml
@@ -1,0 +1,2 @@
+---
+chrony::ntsdumpdir: ~

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -118,8 +118,13 @@ describe 'chrony' do
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file(config_file).with_content(%r{^\s*server #{s} iburst$}) }
             end
-            it { is_expected.to contain_file(config_file).with_content(%r{^\s*driftfile /var/lib/chrony/drift$}) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^\s*driftfile /var/lib/chrony/chrony.drift$}) }
             it { is_expected.to contain_file(config_file).with_content(%r{^\s*rtcsync$}) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^\s*leapsectz right/UTC$}) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^\s*makestep 1 3$}) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^\s*maxupdateskew 100.0$}) }
+
+            it { is_expected.to contain_file(config_file).with_content(%r{^\s*ntsdumpdir /var/lib/chrony$}) } unless facts[:os]['distro']['codename'] == 'focal'
             it { is_expected.to contain_file(config_file).without_content(%r{^\s*dumpdir}) }
             it { is_expected.to contain_file(config_file).without_content(%r{^\s*ntpsigndsocket}) }
             it { is_expected.to contain_file(config_file).without_content(%r{^\s*\n\s*$}) }


### PR DESCRIPTION
These settings match the current Debian package default `chrony.conf`:
https://salsa.debian.org/debian/chrony/-/blob/0eae9a1cd2b03c2aaf1af32c7a0840351d9a91e7/debian/chrony.conf

Ubuntu 20.04 has chrony 3.5, which doesn't have the `ntsdumpdir` directive.