### PR TITLE
os: add openeuler support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,6 +55,19 @@ class chrony::params {
       $rtconutc          = false
       $dumpdir           = undef
     }
+    'Openeuler' : {
+      $package_name      = 'chrony'
+      $cmdacl            = []
+      $config            = '/etc/chrony.conf'
+      $config_keys       = '/etc/chrony.keys'
+      $config_keys_owner = 0
+      $config_keys_group = 0
+      $config_keys_mode  = '0640'
+      $service_name      = 'chronyd'
+      $clientlog         = false
+      $rtconutc          = false
+      $dumpdir           = undef
+    }
 
     default     : {
       fail("The ${module_name} module is not supported on an ${facts['os']['family']} based system.")

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,12 @@
     },
     {
       "operatingsystem": "Gentoo"
+    },
+    {
+      "operatingsystem": "openEuler",
+      "operatingsystemrelease": [
+        "22"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add OS support openEuler for puppet-chrony 1.0.0

#### This Pull Request (PR) fixes the following issues

This PR add [openEuler](https://www.openeuler.org/) as a supporting OS. openEuler is a community-driven Linux distro. 
 We've tested it in our openEuler cluster. We appreciate if this patch can be back ported to puppet-chrony repository.

Thank you!
