### PR TITLE
os: add openeuler support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -50,6 +50,12 @@
     },
     {
       "operatingsystem": "Gentoo"
+    },
+    {
+      "operatingsystem": "openEuler",
+      "operatingsystemrelease": [
+        "22"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add OS support openEuler for puppet-chrony

#### This Pull Request (PR) fixes the following issues
This PR add [openEuler](https://www.openeuler.org/) as a supporting OS. openEuler is a community-driven Linux distro.
We've tested it in our openEuler cluster. We appreciate it if this patch can be back ported to puppet-chrony v3.x branch.

Thank you!
