### PR TITLE
Drop pidfile_workaround from Beaker testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,3 @@ jobs:
   puppet:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3
-    with:
-      pidfile_workaround: 'CentOS'

--- a/.sync.yml
+++ b/.sync.yml
@@ -5,8 +5,5 @@
     - parameter_types
 spec/spec_helper.rb:
   mock_with: ':rspec'
-.github/workflows/ci.yml:
-  with:
-    pidfile_workaround: CentOS
 spec/spec_helper_acceptance.rb:
   unmanaged: false


### PR DESCRIPTION
To see if it's indeed no longer a problem, as suggested in https://github.com/voxpupuli/puppet_metadata/pull/103.