### PR TITLE
init: change `refclocks` data type to `Hash`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -507,20 +507,19 @@ Default value: `undef`
 
 ##### <a name="-chrony--refclocks"></a>`refclocks`
 
-Data type: `Array`
+Data type: `Hash`
 
 This should be a Hash of hardware reference clock drivers to use.  They hash
-can either list a single list of options for the driver, or any array of
-multiple options if the same driver is used for multiple hardware clocks.
+should be an array of hardware clocks and their options for that driver.
 
 Example:
 ```puppet
 refclocks => { 'PPS' => [ '/dev/pps0 lock NMEA refid GPS',
                          '/dev/pps1:clear refid GPS2' ],
-               'SHM' => '0 offset 0.5 delay 0.2 refid NMEA noselect' }
+               'SHM' => [ '0 offset 0.5 delay 0.2 refid NMEA noselect' ] }
 ```
 
-Default value: `[]`
+Default value: `{}`
 
 ##### <a name="-chrony--makestep_seconds"></a>`makestep_seconds`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -509,7 +509,7 @@ Default value: `undef`
 
 Data type: `Hash`
 
-This should be a Hash of hardware reference clock drivers to use.  They hash
+This should be a Hash of hardware reference clock drivers to use.  The hash
 should be an array of hardware clocks and their options for that driver.
 
 Example:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,14 +146,13 @@
 #   Specifies the minimum number of readings kept for tracking of the NIC clock.
 # @param refclocks
 #   This should be a Hash of hardware reference clock drivers to use.  They hash
-#   can either list a single list of options for the driver, or any array of
-#   multiple options if the same driver is used for multiple hardware clocks.
+#   should be an array of hardware clocks and their options for that driver.
 #
 #   Example:
 #   ```puppet
 #   refclocks => { 'PPS' => [ '/dev/pps0 lock NMEA refid GPS',
 #                            '/dev/pps1:clear refid GPS2' ],
-#                  'SHM' => '0 offset 0.5 delay 0.2 refid NMEA noselect' }
+#                  'SHM' => [ '0 offset 0.5 delay 0.2 refid NMEA noselect' ] }
 #   ```
 # @param makestep_seconds
 #   Configures the [`makestep`](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#makestep) `threshold`.
@@ -275,7 +274,7 @@ class chrony (
   String[1] $package_name                                          = 'chrony',
   Optional[String] $package_source                                 = undef,
   Optional[String] $package_provider                               = undef,
-  Array $refclocks                                                 = [],
+  Hash $refclocks                                                  = {},
   Chrony::Servers $peers                                           = [],
   Chrony::Servers $servers                                         = {
     '0.pool.ntp.org' => ['iburst'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,7 +145,7 @@
 # @param minsamples
 #   Specifies the minimum number of readings kept for tracking of the NIC clock.
 # @param refclocks
-#   This should be a Hash of hardware reference clock drivers to use.  They hash
+#   This should be a Hash of hardware reference clock drivers to use.  The hash
 #   should be an array of hardware clocks and their options for that driver.
 #
 #   Example:

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -157,8 +157,10 @@ log <%= $chrony::log_options %>
 <% } -%>
 <% unless $chrony::refclocks.empty { -%>
 
-<%   $chrony::refclocks.each |$driver| { -%>
-refclock <%= $driver.flatten.join(' ') %>
+<%   $chrony::refclocks.each |$driver, $clocks| { -%>
+<%     $clocks.each |$clock| { -%>
+refclock <%= $driver %> <%= $clock %>
+<%     } -%>
 <%   } -%>
 <% } -%>
 <% if $chrony::lock_all { -%>


### PR DESCRIPTION
This updates the refclock parameter data types to be a hash which matches the examples and updates the template to properly generate multiple refclock entries.

This looks to have broken via a combination of #141 and #79. Rather than restore the full variations that were supported prior to #79 a simplified hash structure was chosen.

Fixes #189