### PR TITLE
Add 'orphan' mode flag.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -146,6 +146,7 @@ The following parameters are available in the `chrony` class:
 * [`keys`](#-chrony--keys)
 * [`driftfile`](#-chrony--driftfile)
 * [`local_stratum`](#-chrony--local_stratum)
+* [`local_orphan`](#-chrony--local_orphan)
 * [`ntpsigndsocket`](#-chrony--ntpsigndsocket)
 * [`stratumweight`](#-chrony--stratumweight)
 * [`log_options`](#-chrony--log_options)
@@ -370,6 +371,15 @@ when the local reference is active. Use `false` to not set local_stratum in
 chrony configuration.
 
 Default value: `10`
+
+##### <a name="-chrony--local_orphan"></a>`local_orphan`
+
+Data type: `Boolean`
+
+Put the server in 'orphan' mode when the local reference is active. Does
+nothing if local_stratum is not set.
+
+Default value: `false`
 
 ##### <a name="-chrony--ntpsigndsocket"></a>`ntpsigndsocket`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,9 @@
 #   Override the stratum of the server which will be reported to clients
 #   when the local reference is active. Use `false` to not set local_stratum in
 #   chrony configuration.
+# @param local_orphan
+#   Put the server in 'orphan' mode when the local reference is active. Does
+#   nothing if local_stratum is not set.
 # @param ntpsigndsocket
 #   This sets the location of the Samba ntp_signd socket when it is running as a Domain Controller (DC).
 # @param stratumweight
@@ -268,6 +271,7 @@ class chrony (
   Array[String[1]] $keys                                           = [],
   Stdlib::Unixpath $driftfile                                      = '/var/lib/chrony/drift',
   Variant[Boolean[false],Integer[1,15]] $local_stratum             = 10,
+  Boolean $local_orphan                                            = false,
   Float $logchange                                                 = 0.5,
   Optional[String[1]] $log_options                                 = undef,
   Optional[Integer[0]] $logbanner                                  = undef,

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -538,6 +538,27 @@ describe 'chrony' do
         it { is_expected.not_to contain_file(config_file).with_content(%r{^\s*local stratum}) }
       end
 
+      context 'local orphan default' do
+        let(:params) do
+          {
+            local_stratum: 10
+          }
+        end
+
+        it { is_expected.to contain_file(config_file).with_content(%r{^\s*local stratum 10$\s*$}) }
+      end
+
+      context 'local orphan enabled' do
+        let(:params) do
+          {
+            local_stratum: 10,
+            local_orphan: true
+          }
+        end
+
+        it { is_expected.to contain_file(config_file).with_content(%r{^\s*local stratum 10 orphan$\s*$}) }
+      end
+
       context 'with sub-millisecond value for logchange' do
         let(:params) do
           {

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -102,7 +102,7 @@ port <%= $chrony::port %>
 <% if $chrony::local_stratum { -%>
 
 # Serve time even if not synchronized to any NTP server.
-local stratum <%= $chrony::local_stratum %>
+local stratum <%= $chrony::local_stratum %><%= if $chrony::local_orphan {' orphan'} else {''} %>
 <% } -%>
 <% if $chrony::minsamples { -%>
 


### PR DESCRIPTION
Enable setting the optional 'orphan' flag when using local reference mode.

#### Pull Request (PR) description
Add a new setting to allow controlling the 'orphan' mode modifier to the 'local' reference mode control. Defaults to the current behavior of not setting orphan mode.

#### This Pull Request (PR) fixes the following issues
n/a