### PR TITLE
Eliminate Workaround for Sensitive

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,13 +18,7 @@ class chrony::config {
     ),
   }
 
-  if $chrony::chrony_password =~ Sensitive {
-    # unwrap before Puppet 6.24 can only be called on Sensitive values
-    $chrony_password = $chrony::chrony_password.unwrap
-  } else {
-    $chrony_password = $chrony::chrony_password
-  }
-
+  $chrony_password = $chrony::chrony_password.unwrap
   $keys_params = {
     'chrony_password' => $chrony_password,
     'commandkey' => $chrony::commandkey,


### PR DESCRIPTION
Since Puppet 6 already was dropped in 4b4cc870d6c85ea3f16bde8ad0585e4bfad67b90, this Workaround in not needed anymore.

Fixes 8dbe6b4ee897b2225aae9cec4059cee10d763fdf