### PR TITLE
init: fix `sourcedir` and `confdir` docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -129,8 +129,8 @@ The following parameters are available in the `chrony` class:
 * [`bindaddress`](#-chrony--bindaddress)
 * [`bindcmdaddress`](#-chrony--bindcmdaddress)
 * [`initstepslew`](#-chrony--initstepslew)
-* [`sourcedir`](#-chrony--sourcedir)
 * [`confdir`](#-chrony--confdir)
+* [`sourcedir`](#-chrony--sourcedir)
 * [`cmdacl`](#-chrony--cmdacl)
 * [`cmdport`](#-chrony--cmdport)
 * [`commandkey`](#-chrony--commandkey)
@@ -227,7 +227,7 @@ and to correct the system clock by stepping before normal operation begins.
 
 Default value: `undef`
 
-##### <a name="-chrony--sourcedir"></a>`sourcedir`
+##### <a name="-chrony--confdir"></a>`confdir`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
@@ -235,7 +235,7 @@ The confdir directive includes configuration files with the .conf suffix from a 
 
 Default value: `undef`
 
-##### <a name="-chrony--confdir"></a>`confdir`
+##### <a name="-chrony--sourcedir"></a>`sourcedir`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,9 +60,9 @@
 # @param initstepslew
 #   Allow chronyd to make a rapid measurement of the system clock error at boot time,
 #   and to correct the system clock by stepping before normal operation begins.
-# @param sourcedir
-#   The confdir directive includes configuration files with the .conf suffix from a directory.
 # @param confdir
+#   The confdir directive includes configuration files with the .conf suffix from a directory.
+# @param sourcedir
 #   The sourcedir directive is identical to the confdir directive, except the configuration files have the .sources suffix, they can only specify NTP sources.
 # @param cmdacl
 #   An array of ACLs for monitoring access. This expects a list of directives, for


### PR DESCRIPTION
The docs were swapped.