### PR TITLE
Debian: set `config_keys_group` to `_chrony` to match package configuration

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,4 +1,5 @@
 ---
+chrony::config_keys_group: _chrony
 chrony::driftfile: /var/lib/chrony/chrony.drift
 chrony::leapsectz: right/UTC
 chrony::makestep_seconds: 1

--- a/data/Debian/20.04.yaml
+++ b/data/Debian/20.04.yaml
@@ -1,2 +1,0 @@
----
-chrony::ntsdumpdir: ~

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -130,7 +130,7 @@ describe 'chrony' do
             it { is_expected.to contain_file(config_file).without_content(%r{^\s*\n\s*$}) }
             it { is_expected.to contain_file(keys_file).with_mode('0640') }
             it { is_expected.to contain_file(keys_file).with_owner('0') }
-            it { is_expected.to contain_file(keys_file).with_group('0') }
+            it { is_expected.to contain_file(keys_file).with_group('_chrony') }
             it { is_expected.to contain_file(keys_file).with_replace(true) }
             it { is_expected.to contain_file(keys_file).with_content(sensitive("0 xyzzy\n")) }
           end


### PR DESCRIPTION
- **Remove Ubuntu 20.04 data**
- **Debian: set config_keys_group to _chrony**
