### PR TITLE
README: replace Travis status badge with GitHub Actions status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # puppet-chrony
 
 [![License](https://img.shields.io/github/license/voxpupuli/puppet-chrony.svg)](https://github.com/voxpupuli/puppet-chrony/blob/master/LICENSE)
-[![Build Status](https://secure.travis-ci.org/voxpupuli/puppet-chrony.png?branch=master)](http://travis-ci.org/voxpupuli/puppet-chrony)
+[![Build Status](https://github.com/voxpupuli/puppet-chrony/actions/workflows/ci.yml/badge.svg)](https://github.com/voxpupuli/puppet-chrony/actions/workflows/ci.yml)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/chrony.svg?style=flat)](https://forge.puppetlabs.com/puppet/chrony)
 [![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/chrony.svg?style=flat)](https://forge.puppetlabs.com/puppet/chrony)
 [![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/chrony.svg?style=flat)](https://forge.puppetlabs.com/puppet/chrony)


### PR DESCRIPTION
We haven't used Travis-CI in a long time.