### PR TITLE
Add support for DNS Service record configuration

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,3 +2,4 @@
 fixtures:
   repositories:
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    systemd: https://github.com/voxpupuli/puppet-systemd.git

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ with systemd.
 
 Please review `metadata.json` for a list of requirements.
 
+The DNS Service records feature requires the `dig` command to be installed on the target system.
+
 ### Beginning with chrony
 
 `include 'chrony'` is all you need to get it running. If you
@@ -135,6 +137,25 @@ class { 'chrony':
   wait_ensure => true,
 }
 ```
+
+### Use DNS Service records for dynamic NTP configuration
+
+You can configure chrony to use DNS Service records for dynamic NTP server discovery.
+This feature uses chrony's native `sourcedir` functionality combined with DNS SRV queries
+to automatically discover and configure NTP servers:
+
+```puppet
+class { 'chrony':
+  dnssrv_records => [
+    '_ntp._udp.example.com',
+    '_ntp._udp.backup.example.com',
+  ],
+}
+```
+
+The DNS SRV records are queried periodically (every 30 minutes by default via systemd timer), and
+the discovered servers are written to `.sources` files in `/var/run/chrony-dnssrv` (by default).
+Chrony automatically reloads these sources without requiring a service restart.
 
 ## Reference
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,6 +16,10 @@
 * `chrony::install`: Installs chrony
 * `chrony::service`: Manages the chrony service
 
+### Defined types
+
+* [`chrony::dnssrv`](#chrony--dnssrv): Manages chrony DNS Service records for dynamic NTP configuration
+
 ### Functions
 
 #### Private Functions
@@ -211,6 +215,7 @@ The following parameters are available in the `chrony` class:
 * [`options_template`](#-chrony--options_template)
 * [`ptpport`](#-chrony--ptpport)
 * [`ptpdomain`](#-chrony--ptpdomain)
+* [`dnssrv_records`](#-chrony--dnssrv_records)
 
 ##### <a name="-chrony--bindaddress"></a>`bindaddress`
 
@@ -951,6 +956,116 @@ Default value: `undef`
 Data type: `Optional[Integer[0,255]]`
 
 sets the PTP domain number of transmitted and accepted NTP-over-PTP messages
+
+Default value: `undef`
+
+##### <a name="-chrony--dnssrv_records"></a>`dnssrv_records`
+
+Data type: `Array[String[1]]`
+
+Array of DNS Service records containing the NTP service records for dynamic configuration.
+
+Default value: `[]`
+
+## Defined types
+
+### <a name="chrony--dnssrv"></a>`chrony::dnssrv`
+
+This defined type manages the configuration of DNS Service records for chrony using
+chrony's native sourcedir functionality. It uses a script to query DNS SRV records
+and writes the resolved servers to a .sources file that chrony can reload dynamically.
+Uses systemd timers for periodic DNS SRV record updates.
+
+#### Examples
+
+##### Enable a DNS Service record
+
+```puppet
+chrony::dnssrv { '_ntp._udp.example.com': }
+```
+
+##### Explicitly set the SRV record
+
+```puppet
+chrony::dnssrv { 'example-ntp':
+  srv_record => '_ntp._udp.example.com',
+}
+```
+
+##### Remove a DNS Service record
+
+```puppet
+chrony::dnssrv { '_ntp._udp.example.com':
+  ensure => absent,
+}
+```
+
+##### Custom refresh interval (every hour)
+
+```puppet
+chrony::dnssrv { '_ntp._udp.example.com':
+  timer_oncalendar => 'hourly',
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `chrony::dnssrv` defined type:
+
+* [`srv_record`](#-chrony--dnssrv--srv_record)
+* [`ensure`](#-chrony--dnssrv--ensure)
+* [`sourcedir`](#-chrony--dnssrv--sourcedir)
+* [`poll_interval`](#-chrony--dnssrv--poll_interval)
+* [`timer_oncalendar`](#-chrony--dnssrv--timer_oncalendar)
+* [`timer_randomized_delay`](#-chrony--dnssrv--timer_randomized_delay)
+
+##### <a name="-chrony--dnssrv--srv_record"></a>`srv_record`
+
+Data type: `String[1]`
+
+The DNS Service record to query (e.g., '_ntp._udp.example.com').
+
+Default value: `$title`
+
+##### <a name="-chrony--dnssrv--ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+Whether the DNS SRV record should be enabled or disabled.
+
+Default value: `'present'`
+
+##### <a name="-chrony--dnssrv--sourcedir"></a>`sourcedir`
+
+Data type: `Stdlib::Absolutepath`
+
+The directory where chrony sources files are stored.
+
+Default value: `'/var/run/chrony-dnssrv'`
+
+##### <a name="-chrony--dnssrv--poll_interval"></a>`poll_interval`
+
+Data type: `Integer[0, 24]`
+
+The polling interval for the NTP servers (as a power of 2).
+
+Default value: `6`
+
+##### <a name="-chrony--dnssrv--timer_oncalendar"></a>`timer_oncalendar`
+
+Data type: `String[1]`
+
+The OnCalendar setting for the systemd timer.
+See systemd.time(7) for valid values.
+
+Default value: `'*:0/30'`
+
+##### <a name="-chrony--dnssrv--timer_randomized_delay"></a>`timer_randomized_delay`
+
+Data type: `Optional[String[1]]`
+
+The RandomizedDelaySec setting for the systemd timer.
+Adds a random delay between 0 and the specified duration.
 
 Default value: `undef`
 

--- a/manifests/dnssrv.pp
+++ b/manifests/dnssrv.pp
@@ -1,0 +1,121 @@
+# @summary Manages chrony DNS Service records for dynamic NTP configuration
+#
+# This defined type manages the configuration of DNS Service records for chrony using
+# chrony's native sourcedir functionality. It uses a script to query DNS SRV records
+# and writes the resolved servers to a .sources file that chrony can reload dynamically.
+# Uses systemd timers for periodic DNS SRV record updates.
+#
+# @param srv_record
+#   The DNS Service record to query (e.g., '_ntp._udp.example.com').
+#
+# @param ensure
+#   Whether the DNS SRV record should be enabled or disabled.
+#
+# @param sourcedir
+#   The directory where chrony sources files are stored.
+#
+# @param poll_interval
+#   The polling interval for the NTP servers (as a power of 2).
+#
+# @param timer_oncalendar
+#   The OnCalendar setting for the systemd timer.
+#   See systemd.time(7) for valid values.
+#
+# @param timer_randomized_delay
+#   The RandomizedDelaySec setting for the systemd timer.
+#   Adds a random delay between 0 and the specified duration.
+#
+# @example Enable a DNS Service record
+#   chrony::dnssrv { '_ntp._udp.example.com': }
+#
+# @example Explicitly set the SRV record
+#   chrony::dnssrv { 'example-ntp':
+#     srv_record => '_ntp._udp.example.com',
+#   }
+#
+# @example Remove a DNS Service record
+#   chrony::dnssrv { '_ntp._udp.example.com':
+#     ensure => absent,
+#   }
+#
+# @example Custom refresh interval (every hour)
+#   chrony::dnssrv { '_ntp._udp.example.com':
+#     timer_oncalendar => 'hourly',
+#   }
+#
+define chrony::dnssrv (
+  Enum['present', 'absent'] $ensure               = 'present',
+  String[1] $srv_record                           = $title,
+  Stdlib::Absolutepath $sourcedir                 = '/var/run/chrony-dnssrv',
+  Integer[0, 24] $poll_interval                   = 6,
+  String[1] $timer_oncalendar                     = '*:0/30',
+  Optional[String[1]] $timer_randomized_delay     = undef,
+) {
+  # Sanitize the SRV record name for service/timer names (systemd doesn't like dots)
+  $safe_name = regsubst($srv_record, '[^a-zA-Z0-9_-]', '_', 'G')
+  # Use actual srv_record for filenames
+  $sources_file = "${sourcedir}/${srv_record}.sources"
+  $script_file = "${sourcedir}/${srv_record}.sh"
+
+  file { $script_file:
+    ensure  => stdlib::ensure($ensure, 'file'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    content => epp('chrony/dnssrv_update.sh.epp',
+      {
+        'srv_record'    => $srv_record,
+        'sources_file'  => $sources_file,
+        'poll_interval' => $poll_interval,
+      }
+    ),
+  }
+
+  # Initial population of the sources file
+  if $ensure == 'present' {
+    exec { "dnssrv-initial-${srv_record}":
+      command => $script_file,
+      path    => ['/usr/bin', '/bin'],
+      creates => $sources_file,
+      require => File[$script_file],
+    }
+  }
+
+  # Ensure the sources file is removed when ensure => absent
+  file { $sources_file:
+    ensure => stdlib::ensure($ensure, 'file'),
+  }
+
+  $_timer_randomized_delay_line = $timer_randomized_delay ? {
+    undef   => '',
+    default => "RandomizedDelaySec=${timer_randomized_delay}\n",
+  }
+
+  $_timer_content = @("EOT")
+    [Unit]
+    Description=Update chrony DNS SRV records for ${srv_record}
+
+    [Timer]
+    OnCalendar=${timer_oncalendar}
+    ${_timer_randomized_delay_line}Persistent=true
+
+    [Install]
+    WantedBy=timers.target
+    | EOT
+
+  $_service_content = @("EOT")
+    [Unit]
+    Description=Update chrony DNS SRV records for ${srv_record}
+
+    [Service]
+    Type=oneshot
+    ExecStart=${script_file}
+    | EOT
+
+  systemd::timer { "chrony-dnssrv-${safe_name}.timer":
+    timer_content   => $_timer_content,
+    service_content => $_service_content,
+    active          => $ensure == 'present',
+    enable          => $ensure == 'present',
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -275,6 +275,8 @@
 #   open port to send and receive NTP messages contained in PTP event messages (NTP-over-PTP)
 # @param ptpdomain
 #   sets the PTP domain number of transmitted and accepted NTP-over-PTP messages
+# @param dnssrv_records
+#   Array of DNS Service records containing the NTP service records for dynamic configuration.
 class chrony (
   Array[Stdlib::IP::Address] $bindaddress                          = [],
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
@@ -366,6 +368,7 @@ class chrony (
   String[1] $options_template                                      = 'chrony/chronyd.epp',
   Optional[Integer[0]] $ptpport                                    = undef,
   Optional[Integer[0,255]] $ptpdomain                              = undef,
+  Array[String[1]] $dnssrv_records                                 = [],
 ) {
   if ! $config_keys_manage and $chrony_password != 'unset' {
     fail("Setting \$config_keys_manage false and \$chrony_password at same time in ${module_name} is not possible.")
@@ -378,4 +381,24 @@ class chrony (
   Class['chrony::install']
   -> Class['chrony::config']
   ~> Class['chrony::service']
+
+  # Manage DNS Service records for dynamic configuration
+  if !empty($dnssrv_records) {
+    if !$sourcedir {
+      fail('$sourcedir must be set when using $dnssrv_records')
+    }
+
+    file { $sourcedir:
+      ensure => directory,
+      owner  => root,
+      group  => root,
+      mode   => '0755',
+    }
+
+    $dnssrv_records.each |String $srv_record| {
+      chrony::dnssrv { $srv_record:
+        sourcedir => $sourcedir,
+      }
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.25.1 < 10.0.0"
+    },
+    {
+      "name": "puppet/systemd",
+      "version_requirement": ">= 4.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -663,6 +663,28 @@ describe 'chrony' do
 
         it { expect(config_file_contents.split("\n")).to include('logchange 0.0001') }
       end
+
+      context 'with dnssrv_records' do
+        let(:params) do
+          {
+            sourcedir: '/var/run/chrony-dnssrv',
+            dnssrv_records: ['_ntp._udp.example.com', '_ntp._udp.backup.example.com']
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/var/run/chrony-dnssrv').with_ensure('directory') }
+        it { is_expected.to contain_chrony__dnssrv('_ntp._udp.example.com') }
+        it { is_expected.to contain_chrony__dnssrv('_ntp._udp.backup.example.com') }
+        it { is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.example.com.sh') }
+        it { is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.backup.example.com.sh') }
+        it { is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.example.com.sources') }
+        it { is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.backup.example.com.sources') }
+        it { is_expected.to contain_exec('dnssrv-initial-_ntp._udp.example.com') }
+        it { is_expected.to contain_exec('dnssrv-initial-_ntp._udp.backup.example.com') }
+        it { is_expected.to contain_systemd__timer('chrony-dnssrv-_ntp__udp_example_com.timer') }
+        it { is_expected.to contain_systemd__timer('chrony-dnssrv-_ntp__udp_backup_example_com.timer') }
+      end
     end
   end
 end

--- a/spec/defines/dnssrv_spec.rb
+++ b/spec/defines/dnssrv_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'chrony::dnssrv' do
+  let(:title) { '_ntp._udp.example.com' }
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.example.com.sh').with(
+            ensure: 'file',
+            owner: 'root',
+            group: 'root',
+            mode: '0755'
+          )
+        end
+
+        it do
+          is_expected.to contain_exec('dnssrv-initial-_ntp._udp.example.com').with(
+            creates: '/var/run/chrony-dnssrv/_ntp._udp.example.com.sources'
+          ).that_requires('File[/var/run/chrony-dnssrv/_ntp._udp.example.com.sh]')
+        end
+
+        it do
+          is_expected.to contain_systemd__timer('chrony-dnssrv-_ntp__udp_example_com.timer').with(
+            active: true,
+            enable: true
+          )
+        end
+      end
+
+      context 'with ensure => absent' do
+        let(:params) do
+          {
+            ensure: 'absent'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.example.com.sources').with(
+            ensure: 'absent'
+          )
+        end
+
+        it do
+          is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.example.com.sh').with(
+            ensure: 'absent'
+          )
+        end
+
+        it do
+          is_expected.to contain_systemd__timer('chrony-dnssrv-_ntp__udp_example_com.timer').with(
+            active: false,
+            enable: false
+          )
+        end
+      end
+
+      context 'with custom srv_record' do
+        let(:title) { 'custom-name' }
+        let(:params) do
+          {
+            srv_record: '_ntp._udp.custom.com'
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.custom.com.sh').with(
+            ensure: 'file',
+            owner: 'root',
+            group: 'root',
+            mode: '0755'
+          )
+        end
+
+        it do
+          is_expected.to contain_exec('dnssrv-initial-_ntp._udp.custom.com').with(
+            creates: '/var/run/chrony-dnssrv/_ntp._udp.custom.com.sources'
+          )
+        end
+
+        it do
+          is_expected.to contain_systemd__timer('chrony-dnssrv-_ntp__udp_custom_com.timer').with(
+            active: true,
+            enable: true
+          )
+        end
+
+        it do
+          is_expected.to contain_file('/var/run/chrony-dnssrv/_ntp._udp.custom.com.sources').with(
+            ensure: 'file'
+          )
+        end
+      end
+
+      context 'with custom sourcedir and poll_interval' do
+        let(:params) do
+          {
+            sourcedir: '/custom/path',
+            poll_interval: 8
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_file('/custom/path/_ntp._udp.example.com.sh').with(
+            ensure: 'file',
+            mode: '0755'
+          )
+        end
+
+        it do
+          is_expected.to contain_exec('dnssrv-initial-_ntp._udp.example.com').with(
+            creates: '/custom/path/_ntp._udp.example.com.sources'
+          )
+        end
+
+        it do
+          is_expected.to contain_file('/custom/path/_ntp._udp.example.com.sources').with(
+            ensure: 'file'
+          )
+        end
+      end
+    end
+  end
+end

--- a/templates/dnssrv_update.sh.epp
+++ b/templates/dnssrv_update.sh.epp
@@ -1,0 +1,49 @@
+<%- |
+  String[1] $srv_record,
+  String[1] $sources_file,
+  Integer[0, 24] $poll_interval,
+| -%>
+#!/usr/bin/env bash
+# Managed by Puppet - DO NOT EDIT
+#
+# Updates chrony sources file from DNS SRV record: <%= $srv_record %>
+
+set -euo pipefail
+
+SRV_RECORD='<%= $srv_record %>'
+SOURCES_FILE='<%= $sources_file %>'
+TEMP_FILE="${SOURCES_FILE}.tmp"
+POLL_INTERVAL=<%= $poll_interval %>
+
+# Query DNS SRV records and extract server names
+# SRV records return: priority weight port target
+# We extract the target (4th field)
+SERVERS=$(dig +short SRV "${SRV_RECORD}" | awk '{print $4}')
+
+if [ -z "${SERVERS}" ]; then
+  echo "Warning: No servers found for SRV record ${SRV_RECORD}" >&2
+  exit 1
+fi
+
+{
+  echo "# Generated from DNS SRV record: ${SRV_RECORD}"
+  echo "# Updated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo ""
+  echo "${SERVERS}" | while read -r server; do
+    [ -n "${server}" ] && echo "server ${server} iburst minpoll ${POLL_INTERVAL}"
+  done
+} > "${TEMP_FILE}"
+
+if [ ! -s "${TEMP_FILE}" ]; then
+  echo "Error: Generated sources file is empty" >&2
+  rm -f "${TEMP_FILE}"
+  exit 1
+fi
+
+# Atomically replace the sources file
+mv "${TEMP_FILE}" "${SOURCES_FILE}"
+
+# Reload chrony sources (ignore errors if chrony is not running)
+chronyc reload sources 2>/dev/null || true
+
+exit 0


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for reconfiguration via DNS SRV records via new `dnssrv` type

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-chrony/issues/131

