### PR TITLE
Add EL10 and Ubuntu 26.04 support to `metadata.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@
 
 ### Chrony Puppet Module
 
-Manage chrony time daemon on Archlinux and Redhat
+Manage chrony time daemon on operating systems supported in this module's 'metadata.json'
 
 ## Module Description
 
-The Chrony module handles running chrony in Archlinux and Redhat systems
+The Chrony module handles running chrony on supported operating systems
 with systemd.
 
 ## Setup

--- a/data/RedHat/10.yaml
+++ b/data/RedHat/10.yaml
@@ -1,0 +1,5 @@
+---
+chrony::leapsectz: right/UTC
+chrony::ntsdumpdir: /var/lib/chrony
+chrony::makestep_seconds: 1.0
+chrony::options: '-F 2'

--- a/data/Ubuntu.yaml
+++ b/data/Ubuntu.yaml
@@ -1,5 +1,4 @@
-chrony::leapseclist: ~
-chrony::leapsectz: right/UTC
+chrony::leapseclist: /usr/share/zoneinfo/leap-seconds.list
 chrony::pools:
   ntp.ubuntu.com:
     - iburst

--- a/data/Ubuntu/22.04.yaml
+++ b/data/Ubuntu/22.04.yaml
@@ -1,0 +1,3 @@
+---
+chrony::leapsectz: right/UTC
+chrony::leapseclist: ~

--- a/data/Ubuntu/24.04.yaml
+++ b/data/Ubuntu/24.04.yaml
@@ -1,0 +1,3 @@
+---
+chrony::leapsectz: right/UTC
+chrony::leapseclist: ~

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,8 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -31,21 +32,24 @@
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
@@ -66,7 +70,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "22.04",
-        "24.04"
+        "24.04",
+        "26.04"
       ]
     },
     {

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -8,3 +8,30 @@ if fact('os.family') == 'Archlinux' {
     ensure => directory,
   }
 }
+
+
+# Ubuntu and Debian ships chrony.service with
+# ConditionVirtualization=|!container / |wsl, so systemd refuses to ever
+# start the unit inside a container-based acceptance node -- unrelated to
+# anything Puppet manages. This is a deliberate distribution decision,
+# not a module bug, so the workaround is confined to the test harness
+# rather than shipped in manifests/. See
+# https://github.com/voxpupuli/puppet-chrony/pull/254#issuecomment-5308411879
+
+if fact('os.family') == 'Debian' {
+  file { '/etc/systemd/system/chrony.service.d':
+    ensure => directory,
+  }
+
+  file { '/etc/systemd/system/chrony.service.d/override.conf':
+    ensure  => file,
+    content => "[Unit]\nConditionVirtualization=\n",
+    notify  => Exec['chrony-systemd-daemon-reload'],
+  }
+
+  exec { 'chrony-systemd-daemon-reload':
+    command     => 'systemctl daemon-reload',
+    refreshonly => true,
+    path        => ['/usr/bin', '/bin'],
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

basic update to metadata to allow successful install against enterprise Linux 10 operating systems (Redhat/Rocky/Alma) and Ubuntu 26.04


#### This Pull Request (PR) fixes the following issues

no specific bug fixes just bumping versions for currently supported operating systems. It should be noted that the bump to support Ubuntu 26.04 will work only once a new release is made to include the fixes currently deployed in master, it will not pass against the current module released version due to file location fixes that have not been released from master

