### PR TITLE
Add bindacqaddress option

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -127,6 +127,7 @@ class { 'chrony':
 The following parameters are available in the `chrony` class:
 
 * [`bindaddress`](#-chrony--bindaddress)
+* [`bindacqaddress`](#-chrony--bindacqaddress)
 * [`bindcmdaddress`](#-chrony--bindcmdaddress)
 * [`initstepslew`](#-chrony--initstepslew)
 * [`confdir`](#-chrony--confdir)
@@ -218,6 +219,14 @@ Data type: `Array[Stdlib::IP::Address]`
 
 Array of addresses of interfaces on which chronyd will listen for NTP traffic.
 Listens on all addresses if left empty.
+
+Default value: `[]`
+
+##### <a name="-chrony--bindacqaddress"></a>`bindacqaddress`
+
+Data type: `Array[Stdlib::IP::Address,0,2]`
+
+Array of addresses of interfaces on which chronyd will bind NTP and NTS-KE client sockets.
 
 Default value: `[]`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,8 @@
 # @param bindaddress
 #   Array of addresses of interfaces on which chronyd will listen for NTP traffic.
 #   Listens on all addresses if left empty.
+# @param bindacqaddress
+#   Array of addresses of interfaces on which chronyd will bind NTP and NTS-KE client sockets.
 # @param bindcmdaddress
 #   Array of addresses of interfaces on which chronyd will listen for monitoring command packets.
 # @param initstepslew
@@ -278,6 +280,7 @@
 #   sets the PTP domain number of transmitted and accepted NTP-over-PTP messages
 class chrony (
   Array[Stdlib::IP::Address] $bindaddress                          = [],
+  Array[Stdlib::IP::Address,0,2] $bindacqaddress                   = [],
   Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Optional[String] $initstepslew                                   = undef,
   Array[String] $cmdacl                                            = [],

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -35,6 +35,7 @@ describe 'chrony' do
         it { is_expected.to contain_class('chrony::config').that_notifies('Class[chrony::service]') }
         it { is_expected.to contain_class('chrony::service') }
         it { is_expected.to contain_file(config_file).without_content(%r{^\s*acquisitionport}) }
+        it { is_expected.to contain_file(config_file).without_content(%r{^\s*bindacqaddress}) }
       end
 
       context 'chrony::package' do
@@ -175,6 +176,7 @@ describe 'chrony' do
             sourcedir: '/tmp/chrosources',
             chrony_password: sensitive('sunny'),
             bindaddress: ['10.0.0.1', '::1'],
+            bindacqaddress: ['10.0.0.2', '::2'],
             bindcmdaddress: ['10.0.0.1'],
             initstepslew: '600',
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
@@ -225,6 +227,8 @@ describe 'chrony' do
         it { is_expected.to contain_file(config_file).with_content(%r{^s*deny 10\.0/16$}) }
         it { is_expected.to contain_file(config_file).with_content(%r{^\s*bindaddress 10\.0\.0\.1$}) }
         it { is_expected.to contain_file(config_file).with_content(%r{^\s*bindaddress ::1$}) }
+        it { is_expected.to contain_file(config_file).with_content(%r{^\s*bindacqaddress 10\.0\.0\.2$}) }
+        it { is_expected.to contain_file(config_file).with_content(%r{^\s*bindacqaddress ::2$}) }
         it { is_expected.to contain_file(config_file).with_content(%r{^\s*initstepslew 600$}) }
         it { is_expected.to contain_file(config_file).with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
         it { is_expected.to contain_file(config_file).with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }

--- a/templates/chrony.conf.epp
+++ b/templates/chrony.conf.epp
@@ -92,6 +92,9 @@ bindaddress <%= $addr %>
 <% if $chrony::acquisitionport { -%>
 acquisitionport <%= $chrony::acquisitionport %>
 <% } -%>
+<%  $chrony::bindacqaddress.each |$addr| { -%>
+bindacqaddress <%= $addr %>
+<% } -%>
 <% if $chrony::initstepslew { -%>
 
 # Allow chronyd to make a rapid measurement of the system clock error at boot time,


### PR DESCRIPTION
Implemented:
- New `chrony::bindacqaddress` parameter as `Array[Stdlib::IP::Address]`, default `[]`.
- `bindacqaddress` rendering in `templates/chrony.conf.epp`.
- Spec coverage for default omission and configured IPv4/IPv6 rendering.
- `REFERENCE.md` entry for the new parameter.